### PR TITLE
Refactor registration

### DIFF
--- a/nanshe/imp/registration.py
+++ b/nanshe/imp/registration.py
@@ -245,23 +245,9 @@ def register_mean_offsets(frames2reg,
 
     template_fft = numpy.empty(frames2reg.shape[1:], dtype=complex_type)
 
-    negative_wave_vector = numpy.asarray(template_fft.shape, dtype=float_type)
-    numpy.reciprocal(negative_wave_vector, out=negative_wave_vector)
-    negative_wave_vector *= 2*numpy.pi
-    numpy.negative(negative_wave_vector, out=negative_wave_vector)
-
-    template_fft_indices = xnumpy.cartesian_product(
-        [numpy.arange(_) for _ in template_fft.shape]
+    unit_space_shift_fft = generate_unit_phase_shifts(
+        template_fft.shape, float_type=float_type
     )
-
-    unit_space_shift_fft = template_fft_indices * negative_wave_vector
-    unit_space_shift_fft = unit_space_shift_fft.T.copy()
-    unit_space_shift_fft = unit_space_shift_fft.reshape(
-        (template_fft.ndim,) + template_fft.shape
-    )
-
-    negative_wave_vector = None
-    template_fft_indices = None
 
     this_space_shift_mean = numpy.empty(
         this_space_shift.shape[1:],

--- a/nanshe/imp/registration.py
+++ b/nanshe/imp/registration.py
@@ -185,7 +185,6 @@ def register_mean_offsets(frames2reg,
         numpy.float128 : numpy.complex256
     }
     complex_type = float_complex_mapping[float_type]
-    J = complex_type(1j)
 
     if block_frame_length == -1:
         block_frame_length = len(frames2reg)
@@ -245,10 +244,6 @@ def register_mean_offsets(frames2reg,
 
     template_fft = numpy.empty(frames2reg.shape[1:], dtype=complex_type)
 
-    unit_space_shift_fft = generate_unit_phase_shifts(
-        template_fft.shape, float_type=float_type
-    )
-
     this_space_shift_mean = numpy.empty(
         this_space_shift.shape[1:],
         dtype=this_space_shift.dtype
@@ -262,15 +257,10 @@ def register_mean_offsets(frames2reg,
 
         template_fft[:] = 0
         for range_ij in iters.subrange(0, len(frames2reg), block_frame_length):
-            frames2reg_shifted_fft_ij = numpy.exp(
-                J * numpy.tensordot(
-                       space_shift[range_ij],
-                       unit_space_shift_fft,
-                       axes=[-1, 0]
-                    )
+            frames2reg_shifted_fft_ij = translate_fourier(
+                frames2reg_fft[range_ij] / len(frames2reg),
+                space_shift[range_ij]
             )
-            frames2reg_shifted_fft_ij *= frames2reg_fft[range_ij]
-            frames2reg_shifted_fft_ij /= len(frames2reg)
             template_fft += frames2reg_shifted_fft_ij.sum(axis=0)
 
         for range_ij in iters.subrange(0, len(frames2reg), block_frame_length):

--- a/nanshe/imp/registration.py
+++ b/nanshe/imp/registration.py
@@ -294,8 +294,8 @@ def register_mean_offsets(frames2reg,
                     )
             )
             frames2reg_shifted_fft_ij *= frames2reg_fft[i:j]
+            frames2reg_shifted_fft_ij /= len(frames2reg)
             template_fft += frames2reg_shifted_fft_ij.sum(axis=0)
-        template_fft /= len(frames2reg)
 
         for i, j in iters.lagged_generators_zipped(
                 itertools.chain(

--- a/nanshe/imp/registration.py
+++ b/nanshe/imp/registration.py
@@ -30,6 +30,11 @@ import numpy
 
 
 try:
+    from functools import lru_cache
+except ImportError:
+    from functools32 import lru_cache
+
+try:
     import pyfftw.interfaces.numpy_fft as fft
 except Exception as e:
     warnings.warn(str(e) + ". Falling back to NumPy FFTPACK.", ImportWarning)

--- a/nanshe/imp/registration.py
+++ b/nanshe/imp/registration.py
@@ -421,6 +421,7 @@ def register_mean_offsets(frames2reg,
 
 
 @prof.log_call(trace_logger)
+@lru_cache(maxsize=2)
 def generate_unit_phase_shifts(shape, float_type=float):
     """
         Computes the complex phase shift's angle due to a unit spatial shift.

--- a/nanshe/util/iters.py
+++ b/nanshe/util/iters.py
@@ -597,6 +597,66 @@ def splitting_xrange(a, b=None):
 
 
 @prof.log_call(trace_logger)
+def subrange(start, stop=None, step=None, substep=None):
+    """
+        Generates start and stop values for each subrange.
+
+        Args:
+            start(int):           First value in range (or last if only
+                                  specified value)
+
+            stop(int):            Last value in range
+
+            step(int):            Step between each range
+
+            substep(int):         Step within each range
+
+        Yields:
+            (xrange):             A subrange within the larger range.
+
+        Examples:
+            >>> subrange(5) # doctest: +ELLIPSIS
+            <generator object subrange at 0x...>
+
+            >>> list(subrange(5))
+            [xrange(1), xrange(1, 2), xrange(2, 3), xrange(3, 4), xrange(4, 5)]
+
+            >>> list(subrange(0, 5))
+            [xrange(1), xrange(1, 2), xrange(2, 3), xrange(3, 4), xrange(4, 5)]
+
+            >>> list(subrange(1, 5))
+            [xrange(1, 2), xrange(2, 3), xrange(3, 4), xrange(4, 5)]
+
+            >>> list(subrange(0, 10, 3))
+            [xrange(3), xrange(3, 6), xrange(6, 9), xrange(9, 10)]
+
+            >>> list(subrange(0, 7, 3))
+            [xrange(3), xrange(3, 6), xrange(6, 7)]
+
+            >>> [xrange(0, 3, 2), xrange(3, 6, 2), xrange(6, 7, 2)]
+            [xrange(0, 4, 2), xrange(3, 7, 2), xrange(6, 8, 2)]
+
+            >>> list(subrange(0, 7, 3, 2))
+            [xrange(0, 4, 2), xrange(3, 7, 2), xrange(6, 8, 2)]
+    """
+
+    if stop is None:
+        stop = start
+        start = 0
+
+    if step is None:
+        step = 1
+
+    if substep is None:
+        substep = 1
+
+    range_ends = itertools.chain(xrange(start, stop, step), [stop])
+
+    for i, j in lagged_generators_zipped(range_ends):
+        yield(xrange(i, j, substep))
+
+
+@prof.log_call(trace_logger)
 def cumulative_generator(new_op, new_iter):
     """
         Takes each value from new_iter and applies new_op to it with the result

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ elif sys.argv[1] == "bdist_conda":
         "vigra",
         "spams",
         "rank_filter",
+        "functools32",
         "pyqt",
         "volumina"
     ]
@@ -74,6 +75,7 @@ elif sys.argv[1] == "bdist_conda":
         "vigra",
         "spams",
         "rank_filter",
+        "functools32",
         "pyqt",
         "volumina"
     ]


### PR DESCRIPTION
This adds 3 new functions to help clean up and refactor `register_mean_offsets`.

1. `subrange`, which takes a larger range and creates `xrange`s for some values within that larger range.
2. `generate_unit_phase_shifts`, computes the phase shifts given by a unitary shift in the given dimension of the given shape.
3. `translate_fourier`, computes a translation in using phase shifts in fourier space to find the fourier transform of the translation in position space without having to convert.

Additionally, `generate_unit_phase_shifts` caches its result to ensure that it does not recompute calls that it has seen before.