### PR TITLE
Fix `normalize_data` to allow for no parameters

### DIFF
--- a/nanshe/imp/segment.py
+++ b/nanshe/imp/segment.py
@@ -645,7 +645,7 @@ def normalize_data(new_data, out=None, **parameters):
     renormalized_images(
         out,
         output_array=out,
-        **parameters["renormalized_images"]
+        **parameters.get("renormalized_images", {})
     )
 
     return(out)

--- a/nanshe/imp/segment.py
+++ b/nanshe/imp/segment.py
@@ -591,6 +591,12 @@ def normalize_data(new_data, out=None, **parameters):
             >>> a = numpy.zeros((2,2,2,))
             >>> a[1,1,1] = 1
             >>> a[0,0,0] = 1
+            >>> normalize_data(a)
+            array([[[ 0.8660254 , -0.28867513],
+                    [-0.28867513, -0.28867513]],
+            <BLANKLINE>
+                   [[-0.28867513, -0.28867513],
+                    [-0.28867513,  0.8660254 ]]])
             >>> normalize_data(a, **{"renormalized_images" : { "ord" : 2 }})
             array([[[ 0.8660254 , -0.28867513],
                     [-0.28867513, -0.28867513]],


### PR DESCRIPTION
Allows for no parameters to be provided for `renormalized_images`. This should setup the default `L_2`  normalization.