### PR TITLE
Some useful inspection functions

### DIFF
--- a/nanshe/util/wrappers.py
+++ b/nanshe/util/wrappers.py
@@ -26,6 +26,8 @@ __author__ = "John Kirkham <kirkhamj@janelia.hhmi.org>"
 __date__ = "$Jul 23, 2014 16:24:36 EDT$"
 
 
+import collections
+import inspect
 import itertools
 import functools
 import types
@@ -417,6 +419,41 @@ def unwrap(a_callable):
         unwrapped_callable = unwrapped_callable.__wrapped__
 
     return(unwrapped_callable)
+
+
+def tied_call_args(a_callable, *args, **kwargs):
+    """
+        Ties all the args to their respective variable names.
+
+        Args:
+            a_callable(callable):     some callable.
+            *args(callable):          positional arguments for the callable.
+            **kwargs(callable):       keyword arguments for the callable.
+
+        Returns:
+            args (tuple):             ordered dictionary of arguments name and
+                                      their values, all variadic position
+                                      arguments, all variadic keyword
+                                      arguments.
+    """
+
+    sig = inspect.getargspec(a_callable)
+
+    unsorted_callargs = inspect.getcallargs(a_callable, *args, **kwargs)
+
+    new_args = tuple()
+    if (sig.varargs is not None):
+        new_args = unsorted_callargs[sig.varargs]
+
+    new_kwargs = dict()
+    if (sig.keywords is not None):
+        new_kwargs = unsorted_callargs[sig.keywords]
+
+    callargs = collections.OrderedDict()
+    for each_arg in sig.args:
+        callargs[each_arg] = unsorted_callargs[each_arg]
+
+    return(callargs, new_args, new_kwargs)
 
 
 def with_setup_state(setup=None, teardown=None):

--- a/nanshe/util/wrappers.py
+++ b/nanshe/util/wrappers.py
@@ -456,6 +456,32 @@ def tied_call_args(a_callable, *args, **kwargs):
     return(callargs, new_args, new_kwargs)
 
 
+def repack_call_args(a_callable, *args, **kwargs):
+    """
+        Reorganizes args and kwargs to match the given callables signature.
+
+        Args:
+            a_callable(callable):     some callable.
+            *args(callable):          positional arguments for the callable.
+            **kwargs(callable):       keyword arguments for the callable.
+
+        Returns:
+            args (tuple):             all arguments as passed as position
+                                      arguments, all default arguments and
+                                      all arguments passed as keyword
+                                      arguments.
+    """
+
+    callargs, new_args, new_kwargs = tied_call_args(
+        a_callable, *args, **kwargs
+    )
+
+    new_args = tuple(callargs.values()[:len(args)]) + new_args
+    new_kwargs.update(dict(callargs.items()[len(args):]))
+
+    return(new_args, new_kwargs)
+
+
 def with_setup_state(setup=None, teardown=None):
     """
         Adds setup and teardown callable to a function s.t. they can mutate it.

--- a/nanshe/util/wrappers.py
+++ b/nanshe/util/wrappers.py
@@ -400,6 +400,25 @@ def class_decorate_methods(**method_decorators):
     return(metaclass(MetaMethodsDecorator))
 
 
+def unwrap(a_callable):
+    """
+        Returns the underlying function that was wrapped.
+
+        Args:
+            a_callable(callable):     some wrapped (or not) callable.
+
+        Returns:
+            (callable):               the callable that is no longer wrapped.
+    """
+
+    unwrapped_callable = a_callable
+
+    while hasattr(unwrapped_callable, "__wrapped__"):
+        unwrapped_callable = unwrapped_callable.__wrapped__
+
+    return(unwrapped_callable)
+
+
 def with_setup_state(setup=None, teardown=None):
     """
         Adds setup and teardown callable to a function s.t. they can mutate it.

--- a/tests/test_nanshe/test_util/test_wrappers.py
+++ b/tests/test_nanshe/test_util/test_wrappers.py
@@ -300,6 +300,26 @@ class TestWrappers(object):
         assert args == (3,)
         assert kwargs.items() == [("c", 7)]
 
+    def test_repack_call_args(self):
+        def func_0(a, b=5, *v, **k):
+            return(a + b + sum(v) + sum(k.values()))
+
+        args, kwargs = nanshe.util.wrappers.repack_call_args(func_0, 1)
+        assert args == (1,)
+        assert kwargs.items() == [("b", 5)]
+
+        args, kwargs = nanshe.util.wrappers.repack_call_args(
+            func_0, a=1, c=7
+        )
+        assert args == tuple()
+        assert kwargs.items() == [("a", 1), ("c", 7), ("b", 5)]
+
+        args, kwargs = nanshe.util.wrappers.repack_call_args(
+            func_0, 1, 2, 3, c=7
+        )
+        assert args == (1, 2, 3)
+        assert kwargs.items() == [("c", 7)]
+
 
 def setup_with_setup_state_2(a_callable):
     print("setup_2")

--- a/tests/test_nanshe/test_util/test_wrappers.py
+++ b/tests/test_nanshe/test_util/test_wrappers.py
@@ -264,6 +264,17 @@ class TestWrappers(object):
         assert ClassWrapped.func_0.__wrapped__ != Class.func_0
         assert ClassWrapped.__wrapped__.func_0 == Class.func_0
 
+    def test_unwrap(self):
+        def func_0():
+            pass
+
+        func_1 = nanshe.util.wrappers.identity_wrapper(func_0)
+        func_2 = nanshe.util.wrappers.identity_wrapper(func_1)
+
+        assert nanshe.util.wrappers.unwrap(func_1) == func_0
+        assert nanshe.util.wrappers.unwrap(func_2) != func_1
+        assert nanshe.util.wrappers.unwrap(func_2) == func_0
+
 
 def setup_with_setup_state_2(a_callable):
     print("setup_2")

--- a/tests/test_nanshe/test_util/test_wrappers.py
+++ b/tests/test_nanshe/test_util/test_wrappers.py
@@ -275,6 +275,31 @@ class TestWrappers(object):
         assert nanshe.util.wrappers.unwrap(func_2) != func_1
         assert nanshe.util.wrappers.unwrap(func_2) == func_0
 
+    def test_tied_call_args(self):
+        def func_0(a, b=5, *v, **k):
+            return(a + b + sum(v) + sum(k.values()))
+
+        tied_args, args, kwargs = nanshe.util.wrappers.tied_call_args(
+            func_0, 1
+        )
+        assert tied_args.items() == [("a", 1), ("b", 5)]
+        assert args == tuple()
+        assert kwargs.items() == []
+
+        tied_args, args, kwargs = nanshe.util.wrappers.tied_call_args(
+            func_0, a=1, c=7
+        )
+        assert tied_args.items() == [("a", 1), ("b", 5)]
+        assert args == tuple()
+        assert kwargs.items() == [("c", 7)]
+
+        tied_args, args, kwargs = nanshe.util.wrappers.tied_call_args(
+            func_0, 1, 2, 3, c=7
+        )
+        assert tied_args.items() == [("a", 1), ("b", 2)]
+        assert args == (3,)
+        assert kwargs.items() == [("c", 7)]
+
 
 def setup_with_setup_state_2(a_callable):
     print("setup_2")


### PR DESCRIPTION
Provide the following

* `unwrap` -- finds the inner most object without the `__wrapped__` attribute/
* `tied_call_args` -- ties arguments to their parameter names with the exception variadic arguments, which are returned separately.
* `repack_call_args` -- cleans up arguments so that they fit within a positional and keyword grouping.