### PR TITLE
Log TIFF files as they are appended in the converter

### DIFF
--- a/nanshe/io/xtiff.py
+++ b/nanshe/io/xtiff.py
@@ -358,6 +358,11 @@ def convert_tiffs(new_tiff_filenames,
 
         new_hdf5_dataset_axis_pos = 0
         for each_new_tiff_filename in new_tiff_filenames:
+            # Log the filename in case something goes wrong.
+            trace_logger.info(
+                "Now appending TIFF: \"" + str(each_new_tiff_filename) + "\""
+            )
+
             # Read the data in the format specified.
             each_new_tiff_array = get_standard_tiff_array(
                 each_new_tiff_filename,


### PR DESCRIPTION
Helps when a file is corrupted and grinds everything to a halt to know which one it was. This PR adds this to the log.