### PR TITLE
Add the function `info` to simplify getting `numpy` type info

### DIFF
--- a/nanshe/util/xnumpy.py
+++ b/nanshe/util/xnumpy.py
@@ -54,6 +54,43 @@ trace_logger = prof.getTraceLogger(__name__)
 
 
 @prof.log_call(trace_logger)
+def info(a_type):
+    """
+        Takes a ``numpy.dtype`` or any type that can be converted to a
+        ``numpy.dtype`` and returns its info.
+
+        Args:
+            a_type(type):                  the type to find info for.
+
+        Returns:
+            (np.core.getlimits.info):      info about the type.
+
+        Examples:
+            >>> info(float)
+            finfo(resolution=1e-15, min=-1.7976931348623157e+308, max=1.7976931348623157e+308, dtype=float64)
+
+            >>> info(numpy.float64)
+            finfo(resolution=1e-15, min=-1.7976931348623157e+308, max=1.7976931348623157e+308, dtype=float64)
+
+            >>> info(numpy.float32)
+            finfo(resolution=1e-06, min=-3.4028235e+38, max=3.4028235e+38, dtype=float32)
+
+            >>> info(complex)
+            finfo(resolution=1e-15, min=-1.7976931348623157e+308, max=1.7976931348623157e+308, dtype=float64)
+
+            >>> info(int)
+            iinfo(min=-9223372036854775808, max=9223372036854775807, dtype=int64)
+    """
+
+    a_type = numpy.dtype(a_type).type
+
+    if issubclass(a_type, numpy.integer):
+        return(numpy.iinfo(a_type))
+    else:
+        return(numpy.finfo(a_type))
+
+
+@prof.log_call(trace_logger)
 def to_ctype(a_type):
     """
         Takes a numpy.dtype or any type that can be converted to a numpy.dtype


### PR DESCRIPTION
Picks `numpy.iinfo` if it is some type of integer. Otherwise, picks `numpy.finfo`. If the type is no permissible, it raises a `ValueError`.