### PR TITLE
Unpin `conda-build`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,6 @@ install:
    - conda config --add channels nanshe
    - source activate root
    # Install basic conda dependencies.
-   - touch $HOME/miniconda/conda-meta/pinned
-   - echo "conda-build ==1.16.0" >> $HOME/miniconda/conda-meta/pinned
    - conda update --all
    - conda install conda-build
    # Build the conda package for nanshe.

--- a/.wercker.yml
+++ b/.wercker.yml
@@ -11,8 +11,6 @@ build:
             code: |-
                 conda config --add channels nanshe
                 conda config --set show_channel_urls True
-                touch /opt/conda/conda-meta/pinned
-                echo "conda-build ==1.16.0" >> /opt/conda/conda-meta/pinned
                 source activate root
                 conda update -y --all
                 python setup.py bdist_conda


### PR DESCRIPTION
Releases the pin to version `1.16.0` as the bug ( https://github.com/conda/conda-build/issues/555 ) introduced in the `1.18.0` has been fixed and a new release was made. This should no longer present a problem.