### PR TITLE
Support NumPy 1.10.x

### DIFF
--- a/nanshe/imp/registration.py
+++ b/nanshe/imp/registration.py
@@ -277,10 +277,9 @@ def register_mean_offsets(frames2reg,
         this_space_shift_mean[...] = 0
         for range_ij in iters.subrange(0, len(frames2reg), block_frame_length):
             this_space_shift_mean += this_space_shift[range_ij].sum(axis=0)
-        numpy.round(
-            this_space_shift_mean.astype(float_type) / len(this_space_shift),
-            out=this_space_shift_mean
-        )
+        this_space_shift_mean[...] = numpy.round(
+            this_space_shift_mean.astype(float_type) / len(this_space_shift)
+        ).astype(this_space_shift_mean.dtype)
         for range_ij in iters.subrange(0, len(frames2reg), block_frame_length):
             this_space_shift[range_ij] = xnumpy.find_relative_offsets(
                 this_space_shift[range_ij],

--- a/nanshe/util/xnumpy.py
+++ b/nanshe/util/xnumpy.py
@@ -3109,7 +3109,7 @@ def blocks_split(space_shape, block_shape, block_halo=None):
             "The dimensions of `space_shape` and `block_shape` " + \
             "should be the same."
 
-        block_halo = numpy.zeros(space_shape.shape)
+        block_halo = numpy.zeros_like(space_shape)
 
     uneven_block_division = (space_shape % block_shape != 0)
 

--- a/nanshe/util/xnumpy.py
+++ b/nanshe/util/xnumpy.py
@@ -2356,12 +2356,13 @@ def enumerate_masks_max(new_masks, axis=0):
 
     for i in xrange(new_masks.shape[axis]):
         i = new_enumerated_masks_max.dtype.type(i)
+        one = new_enumerated_masks_max.dtype.type(1)
         numpy.maximum(
             new_enumerated_masks_max,
-            (i+1) * add_singleton_axis_pos(
-                        index_axis_at_pos(new_masks, axis, i),
-                        axis
-                    ),
+            (i + one) * add_singleton_axis_pos(
+                            index_axis_at_pos(new_masks, axis, i),
+                            axis
+                        ),
             out=new_enumerated_masks_max
         )
 

--- a/nanshe/util/xnumpy.py
+++ b/nanshe/util/xnumpy.py
@@ -2355,6 +2355,7 @@ def enumerate_masks_max(new_masks, axis=0):
     )
 
     for i in xrange(new_masks.shape[axis]):
+        i = new_enumerated_masks_max.dtype.type(i)
         numpy.maximum(
             new_enumerated_masks_max,
             (i+1) * add_singleton_axis_pos(


### PR DESCRIPTION
Makes various changes to support NumPy 1.10.x.

* Converts the results of round before storing them. This happens due to a type error. This is probably a good idea in light of this bug ( https://github.com/numpy/numpy/issues/5777 ), which may have affected us.
* Fixes the type used in an array allocation. Defaulted to `float64` before, which is not desirable.
* Given that it is standard practice in NumPy to cast `uint64` and `int64` operations to `float64` ( https://github.com/numpy/numpy/issues/6835 ), previously unknown to me, a workaround was added to make sure a Python `int64` type was casted to `uint64` to ensure the result remained `uint64`.