### PR TITLE
Skip SGE test on Travis for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
    - export SGE_ROOT=/var/lib/gridengine
    - export SGE_CELL=default
    - export DRMAA_LIBRARY_PATH=/usr/lib/libdrmaa.so.1.0
-   - conda install drmaa
+   #- conda install drmaa
    # Install sphinx 1.3 and friends to build documentation.
    - echo "sphinx 1.3.*" >> $HOME/miniconda/envs/testenv/conda-meta/pinned
    - conda install sphinx


### PR DESCRIPTION
Related: https://github.com/travis-ci/travis-ci/issues/5292

The GCE VMs that Travis CI is using have too long of a hostname, which causing the SGE installation/configuration to fail. For now, we will skip these tests. It will probably make Coveralls unhappy. However, they are being tested on Wercker CI. So, this is an acceptable stop gap until they are fixed.