### PR TITLE
Fix SGE install of GCE (Travis)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ before_install:
    - deactivate
    - cd ../..
    - pwd
+   # Fix the hostname to have fewer characters for SGE.
+   - sudo hostname "$(hostname | cut -c1-63)"
 install:
    # Download and configure conda.
    - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,10 @@ before_install:
    - cd ../..
    - pwd
    # Fix the hostname to have fewer characters for SGE.
+   - cat /etc/hosts # optionally check the content *before*
    - sudo hostname "$(hostname | cut -c1-63)"
-   - hostname
-   - cat /etc/hosts
+   - sed -e "s/^\\(127\\.0\\.0\\.1.*\\)/\\1 $(hostname | cut -c1-63)/" /etc/hosts | sudo tee /etc/hosts
+   - cat /etc/hosts # optionally check the content *after*
 install:
    # Download and configure conda.
    - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_install:
    - pwd
    # Fix the hostname to have fewer characters for SGE.
    - sudo hostname "$(hostname | cut -c1-63)"
+   - hostname
 install:
    # Download and configure conda.
    - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
    # Fix the hostname to have fewer characters for SGE.
    - sudo hostname "$(hostname | cut -c1-63)"
    - hostname
+   - echo $HOSTNAME
 install:
    # Download and configure conda.
    - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
    # Fix the hostname to have fewer characters for SGE.
    - sudo hostname "$(hostname | cut -c1-63)"
    - hostname
-   - echo $HOSTNAME
+   - cat /etc/hosts
 install:
    # Download and configure conda.
    - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ before_install:
    - sudo hostname "$(hostname | cut -c1-63)"
    - hostname
    - cat /etc/hosts
-   - sudo echo "127.0.0.1 $(hostname)" >> /etc/hosts
 install:
    # Download and configure conda.
    - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ before_install:
    - sudo hostname "$(hostname | cut -c1-63)"
    - hostname
    - cat /etc/hosts
+   - echo "127.0.0.1 $(hostname)" >> /etc/hosts
 install:
    # Download and configure conda.
    - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ install:
    - export SGE_ROOT=/var/lib/gridengine
    - export SGE_CELL=default
    - export DRMAA_LIBRARY_PATH=/usr/lib/libdrmaa.so.1.0
-   #- conda install drmaa
+   - conda install drmaa
    # Install sphinx 1.3 and friends to build documentation.
    - echo "sphinx 1.3.*" >> $HOME/miniconda/envs/testenv/conda-meta/pinned
    - conda install sphinx

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ before_install:
    - cd ../..
    - pwd
    # Fix the hostname to have fewer characters for SGE.
-   - echo $MAXHOSTNAMELEN
    - sudo hostname "$(hostname | cut -c1-63)"
 install:
    # Download and configure conda.

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install:
    - cd ../..
    - pwd
    # Fix the hostname to have fewer characters for SGE.
+   - echo $MAXHOSTNAMELEN
    - sudo hostname "$(hostname | cut -c1-63)"
 install:
    # Download and configure conda.

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
    - sudo hostname "$(hostname | cut -c1-63)"
    - hostname
    - cat /etc/hosts
-   - echo "127.0.0.1 $(hostname)" >> /etc/hosts
+   - sudo echo "127.0.0.1 $(hostname)" >> /etc/hosts
 install:
    # Download and configure conda.
    - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh


### PR DESCRIPTION
Cuts down the `hostname` to fewer characters to ensure SGE installs successfully. If this ever passes, that means it is working again.