### PR TITLE
Fix `merge_neuron_sets_once` array debug logger 

### DIFF
--- a/nanshe/imp/segment.py
+++ b/nanshe/imp/segment.py
@@ -2959,7 +2959,7 @@ def merge_neuron_sets(new_neuron_set_1,
                       overlap_min_threshold,
                       **parameters):
 
-    merge_neuron_sets_once.recorders.array_debug_recorder = merge_neuron_sets.recorders.array_debug_recorder
+    merge_neuron_sets_repeatedly.recorders.array_debug_recorder = merge_neuron_sets.recorders.array_debug_recorder
     return(merge_neuron_sets_repeatedly(
         new_neuron_set_1,
         new_neuron_set_2,


### PR DESCRIPTION
Appears that `merge_neuron_sets` was configuring the wrong function. This has now been corrected.