### PR TITLE
Use BLAS `syrk` to speed up some `dot`-based operations

### DIFF
--- a/nanshe/util/xnumpy.py
+++ b/nanshe/util/xnumpy.py
@@ -4568,7 +4568,7 @@ def pair_dot_product_partially_normalized(new_vector_set, ord=2):
     # Measure the dot product between any two neurons
     # (i.e. related to the angle of separation)
     vector_pairs_dot_product = scipy.linalg.blas.dsyrk(1, new_vector_set)
-    vector_pairs_dot_product += numpy.tril(vector_pairs_dot_product.T, -1)
+    vector_pairs_dot_product += numpy.triu(vector_pairs_dot_product, 1).T
 
     vector_pairs_dot_product_normalized = vector_pairs_dot_product / new_vector_set_norms_expanded
 
@@ -4764,7 +4764,7 @@ def pair_dot_product_normalized(new_vector_set, ord=2):
     # Measure the dot product between any two neurons
     # (i.e. related to the angle of separation)
     vector_pairs_dot_product = scipy.linalg.blas.dsyrk(1, new_vector_set)
-    vector_pairs_dot_product += numpy.tril(vector_pairs_dot_product.T, -1)
+    vector_pairs_dot_product += numpy.triu(vector_pairs_dot_product, 1).T
 
     # Measure the dot product between any two neurons
     # (i.e. related to the angle of separation)

--- a/nanshe/util/xnumpy.py
+++ b/nanshe/util/xnumpy.py
@@ -30,6 +30,8 @@ import warnings
 import numpy
 import scipy
 
+import scipy.linalg
+import scipy.linalg.blas
 import scipy.misc
 import scipy.ndimage
 import scipy.ndimage.morphology

--- a/nanshe/util/xnumpy.py
+++ b/nanshe/util/xnumpy.py
@@ -4567,9 +4567,7 @@ def pair_dot_product_partially_normalized(new_vector_set, ord=2):
 
     # Measure the dot product between any two neurons
     # (i.e. related to the angle of separation)
-    vector_pairs_dot_product = numpy.dot(
-        new_vector_set, new_vector_set.T
-    )
+    vector_pairs_dot_product = scipy.linalg.blas.dsyrk(1, new_vector_set)
 
     vector_pairs_dot_product_normalized = vector_pairs_dot_product / new_vector_set_norms_expanded
 
@@ -4764,9 +4762,7 @@ def pair_dot_product_normalized(new_vector_set, ord=2):
 
     # Measure the dot product between any two neurons
     # (i.e. related to the angle of separation)
-    vector_pairs_dot_product = numpy.dot(
-        new_vector_set, new_vector_set.T
-    )
+    vector_pairs_dot_product = scipy.linalg.blas.dsyrk(1, new_vector_set)
 
     # Measure the dot product between any two neurons
     # (i.e. related to the angle of separation)

--- a/nanshe/util/xnumpy.py
+++ b/nanshe/util/xnumpy.py
@@ -4568,7 +4568,7 @@ def pair_dot_product_partially_normalized(new_vector_set, ord=2):
     # Measure the dot product between any two neurons
     # (i.e. related to the angle of separation)
     vector_pairs_dot_product = scipy.linalg.blas.dsyrk(1, new_vector_set)
-    vector_pairs_dot_product += numpy.triu(vector_pairs_dot_product, 1).T
+    vector_pairs_dot_product += vector_pairs_dot_product.T - numpy.diag(vector_pairs_dot_product.diagonal())
 
     vector_pairs_dot_product_normalized = vector_pairs_dot_product / new_vector_set_norms_expanded
 
@@ -4764,7 +4764,7 @@ def pair_dot_product_normalized(new_vector_set, ord=2):
     # Measure the dot product between any two neurons
     # (i.e. related to the angle of separation)
     vector_pairs_dot_product = scipy.linalg.blas.dsyrk(1, new_vector_set)
-    vector_pairs_dot_product += numpy.triu(vector_pairs_dot_product, 1).T
+    vector_pairs_dot_product += vector_pairs_dot_product.T - numpy.diag(vector_pairs_dot_product.diagonal())
 
     # Measure the dot product between any two neurons
     # (i.e. related to the angle of separation)

--- a/nanshe/util/xnumpy.py
+++ b/nanshe/util/xnumpy.py
@@ -4568,6 +4568,7 @@ def pair_dot_product_partially_normalized(new_vector_set, ord=2):
     # Measure the dot product between any two neurons
     # (i.e. related to the angle of separation)
     vector_pairs_dot_product = scipy.linalg.blas.dsyrk(1, new_vector_set)
+    vector_pairs_dot_product += numpy.tril(vector_pairs_dot_product.T, -1)
 
     vector_pairs_dot_product_normalized = vector_pairs_dot_product / new_vector_set_norms_expanded
 
@@ -4763,6 +4764,7 @@ def pair_dot_product_normalized(new_vector_set, ord=2):
     # Measure the dot product between any two neurons
     # (i.e. related to the angle of separation)
     vector_pairs_dot_product = scipy.linalg.blas.dsyrk(1, new_vector_set)
+    vector_pairs_dot_product += numpy.tril(vector_pairs_dot_product.T, -1)
 
     # Measure the dot product between any two neurons
     # (i.e. related to the angle of separation)


### PR DESCRIPTION
Related: https://github.com/numpy/numpy/issues/6794
Related: https://github.com/xianyi/OpenBLAS/issues/730

Any BLAS has a special operation when dealing with the multiplication of a matrix by its transpose and it is called `syrk`. This is currently not used by `numpy.dot` (though that may change in the future). To get a bit more of a speedup in this case, we can call the C-API of the BLAS directly by using SciPy. This is what is attempted here.