### PR TITLE
Fix contour bug

### DIFF
--- a/nanshe/util/xnumpy.py
+++ b/nanshe/util/xnumpy.py
@@ -4964,7 +4964,7 @@ def generate_contour(a_image, separation_distance=1.0, margin=1.0):
 
     a_mask_transformed = mahotas.distance(
             a_image
-    ).astype(a_image.dtype)
+    )
 
     above_lower_threshold = (lower_threshold <= a_mask_transformed)
     below_upper_threshold = (a_mask_transformed <= upper_threshold)

--- a/nanshe/util/xnumpy.py
+++ b/nanshe/util/xnumpy.py
@@ -4963,7 +4963,8 @@ def generate_contour(a_image, separation_distance=1.0, margin=1.0):
     upper_threshold = separation_distance + half_thickness
 
     a_mask_transformed = mahotas.distance(
-            a_image
+            a_image,
+            "euclidean"
     )
 
     above_lower_threshold = (lower_threshold <= a_mask_transformed)


### PR DESCRIPTION
Related: https://github.com/nanshe-org/nanshe/pull/320

Turns out there was a bug in the way contours were being generated with Mahotas, which was resulting in contours not being generated or being generated in some strange way. This corrects that. There is a very slight slow down when using euclidean space here. However, it still remains quite fast over all and much faster than SciPy on 2D still. That being said, this is no longer used in domains where speed is relevant.