### PR TITLE
Allow single precision in more operations and other optimizations

### DIFF
--- a/nanshe/imp/segment.py
+++ b/nanshe/imp/segment.py
@@ -2216,7 +2216,7 @@ class ExtendedRegionProps(object):
 
         # Take a subset of the label props that does not include the removal
         # mask (copying may not be necessary as the mask may be as effective).
-        self.props = self.props[~remove_prop_indices_mask].copy()
+        self.props = self.props[~remove_prop_indices_mask]
         # Reduce the count by the number of each label
         self.count["count"] -= label_count_to_remove
 

--- a/nanshe/imp/segment.py
+++ b/nanshe/imp/segment.py
@@ -1700,7 +1700,7 @@ def get_neuron_dtype(shape, dtype):
                      ("max_F", dtype_type),
                      ("gaussian_mean", numpy.float64, (ndim,)),
                      ("gaussian_cov", numpy.float64, (ndim, ndim,)),
-                     ("centroid", dtype_type, (ndim,))]
+                     ("centroid", numpy.float64, (ndim,))]
 
     return(neurons_dtype)
 

--- a/nanshe/imp/segment.py
+++ b/nanshe/imp/segment.py
@@ -1697,7 +1697,7 @@ def get_neuron_dtype(shape, dtype):
                      ("contour", numpy.bool8, shape),
                      ("image", dtype_type, shape),
                      ("area", numpy.float64),
-                     ("max_F", numpy.float64),
+                     ("max_F", dtype_type),
                      ("gaussian_mean", numpy.float64, (ndim,)),
                      ("gaussian_cov", numpy.float64, (ndim, ndim,)),
                      ("centroid", dtype_type, (ndim,))]

--- a/nanshe/imp/segment.py
+++ b/nanshe/imp/segment.py
@@ -1690,15 +1690,17 @@ def get_neuron_dtype(shape, dtype):
     """
 
     ndim = len(shape)
+    dtype = numpy.dtype(dtype)
+    dtype_type = dtype.type
 
     neurons_dtype = [("mask", numpy.bool8, shape),
                      ("contour", numpy.bool8, shape),
-                     ("image", numpy.dtype(dtype).type, shape),
+                     ("image", dtype_type, shape),
                      ("area", numpy.float64),
                      ("max_F", numpy.float64),
                      ("gaussian_mean", numpy.float64, (ndim,)),
                      ("gaussian_cov", numpy.float64, (ndim, ndim,)),
-                     ("centroid", numpy.dtype(dtype).type, (ndim,))]
+                     ("centroid", dtype_type, (ndim,))]
 
     return(neurons_dtype)
 

--- a/nanshe/imp/segment.py
+++ b/nanshe/imp/segment.py
@@ -1769,7 +1769,7 @@ def get_one_neuron(shape, dtype):
 
         Examples:
             >>> get_one_neuron(
-            ...     (3,), numpy.float
+            ...     (3,), numpy.float64
             ... ) #doctest: +NORMALIZE_WHITESPACE
             array([ ([False, False, False],
                      [False, False, False],
@@ -1789,7 +1789,7 @@ def get_one_neuron(shape, dtype):
                           ('centroid', '<f8', (1,))])
 
             >>> get_one_neuron(
-            ...     (2, 3), numpy.float
+            ...     (2, 3), numpy.float64
             ... ) #doctest: +NORMALIZE_WHITESPACE
             array([ ([[False, False, False],
                       [False, False, False]],

--- a/nanshe/imp/segment.py
+++ b/nanshe/imp/segment.py
@@ -3050,8 +3050,8 @@ def merge_neuron_sets_once(new_neuron_set_1,
         # Measure the distance between the two masks
         # (note distance relative to the total mask content of each mask individually)
         new_neuron_set_masks_overlaid_1, new_neuron_set_masks_overlaid_2 = xnumpy.dot_product_partially_normalized(
-            new_neuron_set_1_flattened_mask,
-            new_neuron_set_2_flattened_mask,
+            new_neuron_set_1_flattened_mask.astype(numpy.float32),
+            new_neuron_set_2_flattened_mask.astype(numpy.float32),
             ord=1
         )
 
@@ -3327,7 +3327,7 @@ def merge_neuron_sets_repeatedly(new_neuron_set_1,
         # (note distance relative to the total mask content of each mask
         # individually)
         new_neuron_set_masks_overlaid = xnumpy.pair_dot_product_partially_normalized(
-            new_neuron_set_flattened_mask, ord=1
+            new_neuron_set_flattened_mask.astype(numpy.float32), ord=1
         )
         numpy.fill_diagonal(new_neuron_set_masks_overlaid, 0)
 

--- a/nanshe/imp/segment.py
+++ b/nanshe/imp/segment.py
@@ -3487,7 +3487,7 @@ def merge_neuron_sets_repeatedly(new_neuron_set_1,
 
             new_neuron_set_kept[j] = False
 
-        new_neuron_set = new_neuron_set[new_neuron_set_kept].copy()
+        new_neuron_set = new_neuron_set[new_neuron_set_kept]
 
         logger.debug(
             "Fused \"" + repr(len(new_neuron_set_all_j_fuse)) +

--- a/nanshe/util/xnumpy.py
+++ b/nanshe/util/xnumpy.py
@@ -3226,13 +3226,13 @@ def dot_product(new_vector_set_1, new_vector_set_2):
             array([[ 1.]])
     """
 
-    new_vector_set_1_float = new_vector_set_1.astype(float)
-    new_vector_set_2_float = new_vector_set_2.astype(float)
+    new_vector_set_1 = new_vector_set_1.astype(float)
+    new_vector_set_2 = new_vector_set_2.astype(float)
 
     # Measure the dot product between any two neurons
     # (i.e. related to the angle of separation)
     vector_pairs_dot_product = numpy.dot(
-        new_vector_set_1_float, new_vector_set_2_float.T
+        new_vector_set_1, new_vector_set_2.T
     )
 
     return(vector_pairs_dot_product)
@@ -4838,13 +4838,13 @@ def dot_product_L2_normalized(new_vector_set_1, new_vector_set_2):
                    [ 0.9978158 ,  0.99385869,  0.99111258,  0.98921809]])
     """
 
-    new_vector_set_1_float = new_vector_set_1.astype(float)
-    new_vector_set_2_float = new_vector_set_2.astype(float)
+    new_vector_set_1 = new_vector_set_1.astype(float)
+    new_vector_set_2 = new_vector_set_2.astype(float)
 
     # Measure the angle between any two neurons
     # (i.e. related to the angle of separation)
-    vector_pairs_cosine_angle = 1 - scipy.spatial.distance.cdist(new_vector_set_1_float,
-                                                                 new_vector_set_2_float,
+    vector_pairs_cosine_angle = 1 - scipy.spatial.distance.cdist(new_vector_set_1,
+                                                                 new_vector_set_2,
                                                                  "cosine")
 
     return(vector_pairs_cosine_angle)

--- a/nanshe/util/xnumpy.py
+++ b/nanshe/util/xnumpy.py
@@ -3226,8 +3226,8 @@ def dot_product(new_vector_set_1, new_vector_set_2):
             array([[ 1.]])
     """
 
-    new_vector_set_1 = new_vector_set_1.astype(float)
-    new_vector_set_2 = new_vector_set_2.astype(float)
+    new_vector_set_1 = new_vector_set_1.astype(numpy.float64)
+    new_vector_set_2 = new_vector_set_2.astype(numpy.float64)
 
     # Measure the dot product between any two neurons
     # (i.e. related to the angle of separation)
@@ -4347,7 +4347,7 @@ def masks_overlap_normalized(a, b):
     assert (a.ndim == b.ndim == 2)
     assert (a.shape[1] == b.shape[1])
 
-    out = masks_intersection(a, b).astype(float)
+    out = masks_intersection(a, b).astype(numpy.float64)
     out /= masks_union(a, b)
 
     out[numpy.isnan(out)] = 0
@@ -4838,8 +4838,8 @@ def dot_product_L2_normalized(new_vector_set_1, new_vector_set_2):
                    [ 0.9978158 ,  0.99385869,  0.99111258,  0.98921809]])
     """
 
-    new_vector_set_1 = new_vector_set_1.astype(float)
-    new_vector_set_2 = new_vector_set_2.astype(float)
+    new_vector_set_1 = new_vector_set_1.astype(numpy.float64)
+    new_vector_set_2 = new_vector_set_2.astype(numpy.float64)
 
     # Measure the angle between any two neurons
     # (i.e. related to the angle of separation)

--- a/nanshe/util/xnumpy.py
+++ b/nanshe/util/xnumpy.py
@@ -3353,7 +3353,7 @@ def norm(new_vector_set, ord=2):
     assert (new_vector_set.ndim >= 1)
 
     # Must be double.
-    if not issubclass(new_vector_set.dtype.type, numpy.float64):
+    if not issubclass(new_vector_set.dtype.type, numpy.floating):
         new_vector_set = new_vector_set.astype(numpy.float64)
 
     result = None

--- a/nanshe/util/xnumpy.py
+++ b/nanshe/util/xnumpy.py
@@ -3226,8 +3226,10 @@ def dot_product(new_vector_set_1, new_vector_set_2):
             array([[ 1.]])
     """
 
-    new_vector_set_1 = new_vector_set_1.astype(numpy.float64)
-    new_vector_set_2 = new_vector_set_2.astype(numpy.float64)
+    if not issubclass(new_vector_set_1.dtype.type, numpy.floating):
+        new_vector_set_1 = new_vector_set_1.astype(numpy.float64)
+    if not issubclass(new_vector_set_2.dtype.type, numpy.floating):
+        new_vector_set_2 = new_vector_set_2.astype(numpy.float64)
 
     # Measure the dot product between any two neurons
     # (i.e. related to the angle of separation)
@@ -4452,9 +4454,9 @@ def dot_product_partially_normalized(new_vector_set_1,
     """
 
     # Must be double.
-    if not issubclass(new_vector_set_1.dtype.type, numpy.float64):
+    if not issubclass(new_vector_set_1.dtype.type, numpy.floating):
         new_vector_set_1 = new_vector_set_1.astype(numpy.float64)
-    if not issubclass(new_vector_set_2.dtype.type, numpy.float64):
+    if not issubclass(new_vector_set_2.dtype.type, numpy.floating):
         new_vector_set_2 = new_vector_set_2.astype(numpy.float64)
 
     # Gets all of the norms
@@ -4552,7 +4554,7 @@ def pair_dot_product_partially_normalized(new_vector_set, ord=2):
     """
 
     # Must be double.
-    if not issubclass(new_vector_set.dtype.type, numpy.float64):
+    if not issubclass(new_vector_set.dtype.type, numpy.floating):
         new_vector_set = new_vector_set.astype(numpy.float64)
 
     # Gets all of the norms
@@ -4666,9 +4668,9 @@ def dot_product_normalized(new_vector_set_1, new_vector_set_2, ord=2):
     """
 
     # Must be double.
-    if not issubclass(new_vector_set_1.dtype.type, numpy.float64):
+    if not issubclass(new_vector_set_1.dtype.type, numpy.floating):
         new_vector_set_1 = new_vector_set_1.astype(numpy.float64)
-    if not issubclass(new_vector_set_2.dtype.type, numpy.float64):
+    if not issubclass(new_vector_set_2.dtype.type, numpy.floating):
         new_vector_set_2 = new_vector_set_2.astype(numpy.float64)
 
     # Gets all of the norms
@@ -4749,7 +4751,7 @@ def pair_dot_product_normalized(new_vector_set, ord=2):
     """
 
     # Must be double.
-    if not issubclass(new_vector_set.dtype.type, numpy.float64):
+    if not issubclass(new_vector_set.dtype.type, numpy.floating):
         new_vector_set = new_vector_set.astype(numpy.float64)
 
     # Gets all of the norms
@@ -4838,8 +4840,10 @@ def dot_product_L2_normalized(new_vector_set_1, new_vector_set_2):
                    [ 0.9978158 ,  0.99385869,  0.99111258,  0.98921809]])
     """
 
-    new_vector_set_1 = new_vector_set_1.astype(numpy.float64)
-    new_vector_set_2 = new_vector_set_2.astype(numpy.float64)
+    if not issubclass(new_vector_set_1.dtype.type, numpy.floating):
+        new_vector_set_1 = new_vector_set_1.astype(numpy.float64)
+    if not issubclass(new_vector_set_2.dtype.type, numpy.floating):
+        new_vector_set_2 = new_vector_set_2.astype(numpy.float64)
 
     # Measure the angle between any two neurons
     # (i.e. related to the angle of separation)


### PR DESCRIPTION
Skips casting to double precision if the types are already some form of floating point instead of requiring double precision. Hopefully, this should make some operations faster.