### PR TITLE
Optimize pairwise dot/norm functions

### DIFF
--- a/nanshe/imp/segment.py
+++ b/nanshe/imp/segment.py
@@ -3327,7 +3327,9 @@ def merge_neuron_sets_repeatedly(new_neuron_set_1,
         # (note distance relative to the total mask content of each mask
         # individually)
         new_neuron_set_masks_overlaid = xnumpy.pair_dot_product_partially_normalized(
-            new_neuron_set_flattened_mask.astype(numpy.float32), ord=1
+            new_neuron_set_flattened_mask,
+            ord=1,
+            float_type=numpy.float32
         )
         numpy.fill_diagonal(new_neuron_set_masks_overlaid, 0)
 

--- a/nanshe/util/xnumpy.py
+++ b/nanshe/util/xnumpy.py
@@ -4713,7 +4713,7 @@ def dot_product_normalized(new_vector_set_1, new_vector_set_2, ord=2):
 
 
 @prof.log_call(trace_logger)
-def pair_dot_product_normalized(new_vector_set, ord=2):
+def pair_dot_product_normalized(new_vector_set, ord=2, float_type=None):
     """
         Determines the dot product between a pair of vectors from each set and
         divides them by the norm of the two.
@@ -4723,6 +4723,8 @@ def pair_dot_product_normalized(new_vector_set, ord=2):
 
             ord(optional):                        basically the same arguments
                                                   as numpy.linalg.norm.
+
+            float_type(type):                     some form of float
 
         Returns:
             (numpy.ndarray):                      an array with the normalized
@@ -4786,9 +4788,18 @@ def pair_dot_product_normalized(new_vector_set, ord=2):
 
     is_bool = (new_vector_set.dtype == bool)
 
-    # Must be double.
-    if not issubclass(new_vector_set.dtype.type, numpy.floating):
-        new_vector_set = new_vector_set.astype(numpy.float64)
+    if float_type is not None:
+        float_type = numpy.dtype(float_type).type
+        assert issubclass(float_type, numpy.floating)
+
+        if not issubclass(new_vector_set.dtype.type, float_type):
+            new_vector_set = new_vector_set.astype(float_type)
+    else:
+        float_type = numpy.float64
+        if not issubclass(new_vector_set.dtype.type, numpy.floating):
+            new_vector_set = new_vector_set.astype(float_type)
+        else:
+            float_type = new_vector_set.dtype.type
 
     # Measure the dot product between any two neurons
     # (i.e. related to the angle of separation)

--- a/nanshe/util/xnumpy.py
+++ b/nanshe/util/xnumpy.py
@@ -4795,7 +4795,10 @@ def pair_dot_product_normalized(new_vector_set, ord=2):
     )
 
     # Gets all of the norms
-    new_vector_set_norms = norm(new_vector_set, ord=ord)
+    if ord == 2:
+        new_vector_set_norms = numpy.sqrt(vector_pairs_dot_product.diagonal())
+    else:
+        new_vector_set_norms = norm(new_vector_set, ord=ord)
 
     # Finds the product of each combination for normalization
     norm_products = all_permutations_operation(

--- a/nanshe/util/xnumpy.py
+++ b/nanshe/util/xnumpy.py
@@ -4568,6 +4568,8 @@ def pair_dot_product_partially_normalized(new_vector_set, ord=2):
 
     assert ord > 0
 
+    is_bool = (new_vector_set.dtype == bool)
+
     # Must be double.
     if not issubclass(new_vector_set.dtype.type, numpy.floating):
         new_vector_set = new_vector_set.astype(numpy.float64)
@@ -4579,7 +4581,14 @@ def pair_dot_product_partially_normalized(new_vector_set, ord=2):
     )
 
     # Gets all of the norms
-    if ord == 2:
+    if is_bool:
+        new_vector_set_norms = vector_pairs_dot_product.diagonal()
+        if ord != numpy.inf:
+            inv_ord = 1.0 / float_type(ord)
+            new_vector_set_norms = new_vector_set_norms ** inv_ord
+        else:
+            new_vector_set_norms = (new_vector_set_norms > 0).astype(float_type)
+    elif ord == 2:
         new_vector_set_norms = numpy.sqrt(vector_pairs_dot_product.diagonal())
     else:
         new_vector_set_norms = norm(new_vector_set, ord=ord)

--- a/nanshe/util/xnumpy.py
+++ b/nanshe/util/xnumpy.py
@@ -4572,6 +4572,12 @@ def pair_dot_product_partially_normalized(new_vector_set, ord=2):
     if not issubclass(new_vector_set.dtype.type, numpy.floating):
         new_vector_set = new_vector_set.astype(numpy.float64)
 
+    # Measure the dot product between any two neurons
+    # (i.e. related to the angle of separation)
+    vector_pairs_dot_product = numpy.dot(
+        new_vector_set, new_vector_set.T
+    )
+
     # Gets all of the norms
     new_vector_set_norms = norm(new_vector_set, ord)
 
@@ -4582,10 +4588,6 @@ def pair_dot_product_partially_normalized(new_vector_set, ord=2):
 
     # Measure the dot product between any two neurons
     # (i.e. related to the angle of separation)
-    vector_pairs_dot_product = numpy.dot(
-        new_vector_set, new_vector_set.T
-    )
-
     vector_pairs_dot_product_normalized = vector_pairs_dot_product / new_vector_set_norms_expanded
 
     return(vector_pairs_dot_product_normalized)

--- a/nanshe/util/xnumpy.py
+++ b/nanshe/util/xnumpy.py
@@ -4788,18 +4788,18 @@ def pair_dot_product_normalized(new_vector_set, ord=2):
     if not issubclass(new_vector_set.dtype.type, numpy.floating):
         new_vector_set = new_vector_set.astype(numpy.float64)
 
+    # Measure the dot product between any two neurons
+    # (i.e. related to the angle of separation)
+    vector_pairs_dot_product = numpy.dot(
+        new_vector_set, new_vector_set.T
+    )
+
     # Gets all of the norms
     new_vector_set_norms = norm(new_vector_set, ord=ord)
 
     # Finds the product of each combination for normalization
     norm_products = all_permutations_operation(
         operator.mul, new_vector_set_norms, new_vector_set_norms
-    )
-
-    # Measure the dot product between any two neurons
-    # (i.e. related to the angle of separation)
-    vector_pairs_dot_product = numpy.dot(
-        new_vector_set, new_vector_set.T
     )
 
     # Measure the dot product between any two neurons

--- a/nanshe/util/xnumpy.py
+++ b/nanshe/util/xnumpy.py
@@ -3349,6 +3349,8 @@ def norm(new_vector_set, ord=2):
             array([], shape=(2, 0), dtype=float64)
     """
 
+    assert ord > 0
+
     # Needs to have at least one vector
     assert (new_vector_set.ndim >= 1)
 
@@ -4453,6 +4455,8 @@ def dot_product_partially_normalized(new_vector_set_1,
                     [ 7.05562316,  7.02764221,  7.00822427,  6.99482822]]))
     """
 
+    assert ord > 0
+
     # Must be double.
     if not issubclass(new_vector_set_1.dtype.type, numpy.floating):
         new_vector_set_1 = new_vector_set_1.astype(numpy.float64)
@@ -4561,6 +4565,8 @@ def pair_dot_product_partially_normalized(new_vector_set, ord=2):
             array([[ 1.        ,  1.        ],
                    [ 0.79370053,  1.58740105]])
     """
+
+    assert ord > 0
 
     # Must be double.
     if not issubclass(new_vector_set.dtype.type, numpy.floating):
@@ -4676,6 +4682,8 @@ def dot_product_normalized(new_vector_set_1, new_vector_set_2, ord=2):
                    [ 0.9978158 ,  0.99385869,  0.99111258,  0.98921809]])
     """
 
+    assert ord > 0
+
     # Must be double.
     if not issubclass(new_vector_set_1.dtype.type, numpy.floating):
         new_vector_set_1 = new_vector_set_1.astype(numpy.float64)
@@ -4773,6 +4781,8 @@ def pair_dot_product_normalized(new_vector_set, ord=2):
             array([[ 1.        ,  0.79370053],
                    [ 0.79370053,  1.25992105]])
     """
+
+    assert ord > 0
 
     # Must be double.
     if not issubclass(new_vector_set.dtype.type, numpy.floating):

--- a/nanshe/util/xnumpy.py
+++ b/nanshe/util/xnumpy.py
@@ -4784,6 +4784,8 @@ def pair_dot_product_normalized(new_vector_set, ord=2):
 
     assert ord > 0
 
+    is_bool = (new_vector_set.dtype == bool)
+
     # Must be double.
     if not issubclass(new_vector_set.dtype.type, numpy.floating):
         new_vector_set = new_vector_set.astype(numpy.float64)
@@ -4795,7 +4797,14 @@ def pair_dot_product_normalized(new_vector_set, ord=2):
     )
 
     # Gets all of the norms
-    if ord == 2:
+    if is_bool:
+        new_vector_set_norms = vector_pairs_dot_product.diagonal()
+        if ord != numpy.inf:
+            inv_ord = 1.0 / float_type(ord)
+            new_vector_set_norms = new_vector_set_norms ** inv_ord
+        else:
+            new_vector_set_norms = (new_vector_set_norms > 0).astype(float_type)
+    elif ord == 2:
         new_vector_set_norms = numpy.sqrt(vector_pairs_dot_product.diagonal())
     else:
         new_vector_set_norms = norm(new_vector_set, ord=ord)

--- a/nanshe/util/xnumpy.py
+++ b/nanshe/util/xnumpy.py
@@ -4579,7 +4579,10 @@ def pair_dot_product_partially_normalized(new_vector_set, ord=2):
     )
 
     # Gets all of the norms
-    new_vector_set_norms = norm(new_vector_set, ord)
+    if ord == 2:
+        new_vector_set_norms = numpy.sqrt(vector_pairs_dot_product.diagonal())
+    else:
+        new_vector_set_norms = norm(new_vector_set, ord=ord)
 
     # Expand the norms to have a shape equivalent to vector_pairs_dot_product
     new_vector_set_norms_expanded = expand_view(

--- a/nanshe/util/xnumpy.py
+++ b/nanshe/util/xnumpy.py
@@ -4582,7 +4582,7 @@ def pair_dot_product_partially_normalized(new_vector_set, ord=2):
 
     vector_pairs_dot_product_normalized = vector_pairs_dot_product / new_vector_set_norms_expanded
 
-    return((vector_pairs_dot_product_normalized))
+    return(vector_pairs_dot_product_normalized)
 
 
 @prof.log_call(trace_logger)

--- a/nanshe/util/xnumpy.py
+++ b/nanshe/util/xnumpy.py
@@ -4490,7 +4490,7 @@ def dot_product_partially_normalized(new_vector_set_1,
 
 
 @prof.log_call(trace_logger)
-def pair_dot_product_partially_normalized(new_vector_set, ord=2):
+def pair_dot_product_partially_normalized(new_vector_set, ord=2, float_type=None):
     """
         Determines the dot product between the two pairs of vectors from each
         set and creates a tuple with the dot product divided by one norm or the
@@ -4501,6 +4501,8 @@ def pair_dot_product_partially_normalized(new_vector_set, ord=2):
 
             ord(optional):                        basically the same argument
                                                   as numpy.linalg.norm
+
+            float_type(type):                     some form of float
 
         Returns:
             (numpy.ndarray):                      an array with the normalized
@@ -4570,9 +4572,18 @@ def pair_dot_product_partially_normalized(new_vector_set, ord=2):
 
     is_bool = (new_vector_set.dtype == bool)
 
-    # Must be double.
-    if not issubclass(new_vector_set.dtype.type, numpy.floating):
-        new_vector_set = new_vector_set.astype(numpy.float64)
+    if float_type is not None:
+        float_type = numpy.dtype(float_type).type
+        assert issubclass(float_type, numpy.floating)
+
+        if not issubclass(new_vector_set.dtype.type, float_type):
+            new_vector_set = new_vector_set.astype(float_type)
+    else:
+        float_type = numpy.float64
+        if not issubclass(new_vector_set.dtype.type, numpy.floating):
+            new_vector_set = new_vector_set.astype(float_type)
+        else:
+            float_type = new_vector_set.dtype.type
 
     # Measure the dot product between any two neurons
     # (i.e. related to the angle of separation)


### PR DESCRIPTION
This optimizes the pairwise dot/norm functions for special cases like the L<sub>2</sub> norm or `bool` types.

In the case of L<sub>2</sub>, we have already computed the square of the norms by performing the pairwise dot product for the diagonal of matrix. That means we need not compute the norm separately, but merely need to take the square root of the diagonal.

In the case of the bool type, we have already computed `p`-th power of the norms by performing the pairwise dot product for the diagonal of matrix. As a result, we merely need to take the `p`-th root of the diagonal to find the norms.

These were not optimized previously as they were not believed to be rate limiting. They still do not consume the bulk of the time. However, these optimizations should cut out calling `norm` and result in a notable speedup.