### PR TITLE
setup.py: Install nomkl.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ elif sys.argv[1] == "bdist_conda":
     from distutils.command.bdist_conda import CondaDistribution as Distribution
 
     build_requires = [
+        "nomkl",
         "openblas",
         "fftw",
         "setuptools",
@@ -63,6 +64,7 @@ elif sys.argv[1] == "bdist_conda":
     ]
 
     install_requires = [
+        "nomkl",
         "openblas",
         "fftw",
         "setuptools",


### PR DESCRIPTION
Make sure `nomkl` is listed in our build and install requirements even though it is required by `openblas`. This seems to improve behavior when adding other dependencies that make use of `openblas`.