### PR TITLE
Suppress TRACE logging by default.

### DIFF
--- a/nanshe/util/prof.py
+++ b/nanshe/util/prof.py
@@ -41,6 +41,9 @@ from nanshe.util import wrappers
 # unless otherwise specified, in which case this does nothing.
 logging.basicConfig(level=logging.DEBUG, stream=sys.stderr)
 
+# Suppress TRACE logging by default.
+logging.getLogger("TRACE").setLevel(logging.INFO)
+
 
 def getSpecialLogger(logger_prefix, name, *args, **kwargs):
     """


### PR DESCRIPTION
The `TRACE` logging is a bit noisy and also floods CLI tools when checking help. Mainly this is useful for checking run times of functions or looking for when things go wrong in a difficult to inspect function. For these reasons, this should be opt-in and not default enabled.