### PR TITLE
WIP: Corrected SPAMS functions to handle Fortran order

### DIFF
--- a/nanshe/box/spams_sandbox.py
+++ b/nanshe/box/spams_sandbox.py
@@ -103,7 +103,7 @@ def call_multiprocessing_queue_spams_trainDL(*args, **kwargs):
     )
     p.start()
     result = out_queue.get()
-    result = result.copy()
+    result = result.copy(order='A')
     p.join()
 
     if p.exitcode != 0: raise SPAMSException(
@@ -387,6 +387,6 @@ def call_spams_trainDL(*args, **kwargs):
     import spams
 
     result = spams.trainDL(*args, **kwargs)
-    result = result.copy()
+    result = result.copy(order='A')
 
     return(result)

--- a/nanshe/imp/segment.py
+++ b/nanshe/imp/segment.py
@@ -842,7 +842,7 @@ def generate_dictionary(new_data, initial_dictionary=None, **parameters):
     # Fix dictionary so that the first index will be the particular image.
     # The rest will be the shape of an image (same as input shape).
     new_dictionary = new_dictionary.transpose()
-    new_dictionary = numpy.asarray(new_dictionary, dtype=new_data.dtype.type)
+    new_dictionary = numpy.ascontiguousarray(new_dictionary, dtype=new_data.dtype.type)
     new_dictionary = new_dictionary.reshape(
         (-1,) + new_data.shape[1:]
     )

--- a/tests/test_nanshe/test_box/test_spams_sandbox.py
+++ b/tests/test_nanshe/test_box/test_spams_sandbox.py
@@ -78,6 +78,7 @@ class TestSpamsSandbox(object):
 
         self.g = self.g.transpose()
         d = d.transpose()
+        d = numpy.ascontiguousarray(d)
 
         assert (self.g.shape == d.shape)
 
@@ -129,6 +130,7 @@ class TestSpamsSandbox(object):
 
         self.g3 = self.g3.transpose()
         d3 = d3.transpose()
+        d3 = numpy.ascontiguousarray(d3)
 
         assert (self.g3.shape == d3.shape)
 
@@ -279,6 +281,7 @@ class TestSpamsSandbox(object):
 
         self.g = self.g.transpose()
         d = d.transpose()
+        d = numpy.ascontiguousarray(d)
 
         assert (self.g.shape == d.shape)
 
@@ -325,6 +328,7 @@ class TestSpamsSandbox(object):
 
         self.g3 = self.g3.transpose()
         d3 = d3.transpose()
+        d3 = numpy.ascontiguousarray(d3)
 
         assert (self.g3.shape == d3.shape)
 
@@ -926,6 +930,7 @@ class TestSpamsSandbox(object):
 
         self.g = self.g.transpose()
         d = d.transpose()
+        d = numpy.ascontiguousarray(d)
 
         assert (self.g.shape == d.shape)
 
@@ -972,6 +977,7 @@ class TestSpamsSandbox(object):
 
         self.g3 = self.g3.transpose()
         d3 = d3.transpose()
+        d3 = numpy.ascontiguousarray(d3)
 
         assert (self.g3.shape == d3.shape)
 


### PR DESCRIPTION
Ensure that the Fortran ordered array returned by SPAMS remains that was so that the wrapper box functions behave correctly.

**WIP:** Still needs some more tweaks for testing.