### PR TITLE
tests: Make fewer 2D blocks for testing the learner

### DIFF
--- a/tests/test_nanshe/test_learner.py
+++ b/tests/test_nanshe/test_learner.py
@@ -126,7 +126,7 @@ def setup_2d(a_callable):
         "generate_neurons_blocks" : {
             "num_processes" : 4,
             "block_shape" : [10000, -1, -1],
-            "num_blocks" : [-1, 5, 5],
+            "num_blocks" : [-1, 2, 2],
             "half_border_shape" : [0, 5, 5],
             "half_window_shape" : [50, 20, 20],
 
@@ -248,7 +248,7 @@ def setup_2d(a_callable):
         "generate_neurons_blocks" : {
             "num_processes" : 4,
             "block_shape" : [10000, -1, -1],
-            "num_blocks" : [-1, 5, 5],
+            "num_blocks" : [-1, 2, 2],
             "half_border_shape" : [0, 5, 5],
             "half_window_shape" : [50, 20, 20],
 


### PR DESCRIPTION
Use fewer 2D blocks for testing the learner. This should cut down the number of queued jobs and better use the restricted bandwidth. Also, as there is less overlapped area that will be used in calculations, this should take less total CPU time as well. Finally, this is useful for testing a case where positivity constraints are needed to get the right answer.