### PR TITLE
Python 3 CI (temporarily restricted)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: generic
 env:
    - PYTHON_VERSION="2.7"
+   - PYTHON_VERSION="3.5"
 before_install:
    # Get the tag if it wasn't provided. Travis doesn't provide this if it isn't a tagged build.
    - if [ -z $TRAVIS_TAG ]; then TRAVIS_TAG=`git tag --contains` ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 language: generic
 env:
-   - PYTHON_VERSION="2.7"
+   - PYTHON_VERSION="2.7" DEPLOY_DOCS=true
    - PYTHON_VERSION="3.5"
 before_install:
+   # If `$DEPLOY_DOCS` is unset, make it `false` by default.
+   - if [ -z $DEPLOY_DOCS ]; then DEPLOY_DOCS=false; fi
    # Get the tag if it wasn't provided. Travis doesn't provide this if it isn't a tagged build.
    - if [ -z $TRAVIS_TAG ]; then TRAVIS_TAG=`git tag --contains` ; fi
    - echo $TRAVIS_TAG
@@ -98,7 +100,7 @@ after_success:
    # Commit changes and push. Reference commit used and tag if relevant.
    - git add -A
    - if [ -z $TRAVIS_TAG ]; then git commit -m "Rebuilt documentation for commit (${TRAVIS_COMMIT})." --allow-empty ; else git commit -m "Rebuilt documentation for commit (${TRAVIS_COMMIT}) and tag (${TRAVIS_TAG})." --allow-empty ; fi
-   - git push -q origin gh-pages > /dev/null 2>&1; echo $?
+   - $DEPLOY_DOCS && (git push -q origin gh-pages > /dev/null 2>&1; echo $?)
    # Check to see if this is a release. If so, create and upload binaries.
    - if [ -z $TRAVIS_TAG ]; then exit 0 ; fi
    - git checkout $TRAVIS_TAG

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ install:
    - conda install nose-timer
    - echo "coverage 3.*" >> $HOME/miniconda/envs/testenv/conda-meta/pinned
    - conda install coverage
-   - conda install docstring-coverage
+   - conda install docstring-coverage || true
    # Clean up downloads as there are quite a few and they waste space/memory.
    - sudo apt-get clean
    - conda clean -tipsy
@@ -66,7 +66,7 @@ script:
    # Build documentation.
    - python setup.py build_sphinx
    # Get info on docstring coverage.
-   - docstring-coverage nanshe | tee .docstring-coverage
+   - (hash docstring-coverage && docstring-coverage nanshe | tee .docstring-coverage) || true
 after_success:
    # Install packages for submitting coverage results when they are needed.
    - conda install python-coveralls
@@ -76,7 +76,7 @@ after_success:
    - if [ $TRAVIS_PULL_REQUEST != "false" ] || [ $TRAVIS_REPO_SLUG != "nanshe-org/nanshe" ] || [ $TRAVIS_BRANCH != "master" ]; then exit 0 ; fi
    # Save documentation and documentation coverage statistics.
    - mv build/sphinx/html ../nanshe-git-docs
-   - mv .docstring-coverage ../nanshe-git-docs
+   - mv .docstring-coverage ../nanshe-git-docs || true
    # Update credentials
    - git config --global user.name "Travis CI"
    - git config --global user.email "noreply@travis-ci.org"
@@ -92,7 +92,7 @@ after_success:
    - rm -rf * .*
    - mv ../nanshe-git-docs/.nojekyll .
    - mv ../nanshe-git-docs/.git .
-   - mv ../nanshe-git-docs/.docstring-coverage .
+   - mv ../nanshe-git-docs/.docstring-coverage . || true
    - mv ../nanshe-git-docs/* .
    - rm -rf ../nanshe-git-docs
    # Commit changes and push. Reference commit used and tag if relevant.

--- a/setup.all.cfg
+++ b/setup.all.cfg
@@ -3,6 +3,7 @@ verbosity=3
 with-doctest=1
 doctest-tests=1
 with-coverage=1
+ignore-files=viewer.py
 [build_sphinx]
 builder=html
 [versioneer]

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,7 @@ verbosity=3
 with-doctest=1
 doctest-tests=1
 with-coverage=1
+ignore-files=viewer.py
 [build_sphinx]
 builder=html
 [versioneer]

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ elif sys.argv[1] == "bdist_conda":
         "scikit-learn",
         "mahotas",
         "vigra",
-        "spams",
         "rank_filter"
     ]
 
@@ -77,7 +76,6 @@ elif sys.argv[1] == "bdist_conda":
         "scikit-learn",
         "mahotas",
         "vigra",
-        "spams",
         "rank_filter"
     ]
 
@@ -90,10 +88,12 @@ elif sys.argv[1] == "bdist_conda":
         ]
     if sys.version_info < (3,):
         build_requires += [
+            "spams",
             "pyqt",
             "volumina"
         ]
         install_requires += [
+            "spams",
             "pyqt",
             "volumina"
         ]

--- a/tests/test_nanshe/test_box/test_spams_sandbox.py
+++ b/tests/test_nanshe/test_box/test_spams_sandbox.py
@@ -4,6 +4,8 @@ __author__ = "John Kirkham <kirkhamj@janelia.hhmi.org>"
 __date__ = "$Aug 05, 2014 17:38:58 EDT$"
 
 
+import imp
+
 import nose
 import nose.plugins
 import nose.plugins.attrib
@@ -21,6 +23,14 @@ import numpy
 import nanshe.box.spams_sandbox
 
 import nanshe.syn.data
+
+
+has_spams = False
+try:
+    imp.find_module("spams")
+    has_spams = True
+except ImportError:
+    pass
 
 
 try:
@@ -62,6 +72,11 @@ class TestSpamsSandbox(object):
         self.g3 = numpy.asfortranarray(self.g3)
 
     def test_run_multiprocessing_queue_spams_trainDL_1(self):
+        if not has_spams:
+            raise nose.SkipTest(
+                "Cannot run this test without SPAMS being installed."
+            )
+
         out_queue = Queue()
 
         nanshe.box.spams_sandbox.run_multiprocessing_queue_spams_trainDL(
@@ -113,6 +128,11 @@ class TestSpamsSandbox(object):
 
     @nose.plugins.attrib.attr("3D")
     def test_run_multiprocessing_queue_spams_trainDL_2(self):
+        if not has_spams:
+            raise nose.SkipTest(
+                "Cannot run this test without SPAMS being installed."
+            )
+
         out_queue = Queue()
 
         nanshe.box.spams_sandbox.run_multiprocessing_queue_spams_trainDL(
@@ -163,6 +183,11 @@ class TestSpamsSandbox(object):
         assert (len(unmatched_g3) == 0)
 
     def test_run_multiprocessing_queue_spams_trainDL_3(self):
+        if not has_spams:
+            raise nose.SkipTest(
+                "Cannot run this test without SPAMS being installed."
+            )
+
         out_queue = Queue()
 
         nanshe.box.spams_sandbox.run_multiprocessing_queue_spams_trainDL(
@@ -216,6 +241,11 @@ class TestSpamsSandbox(object):
 
     @nose.plugins.attrib.attr("3D")
     def test_run_multiprocessing_queue_spams_trainDL_4(self):
+        if not has_spams:
+            raise nose.SkipTest(
+                "Cannot run this test without SPAMS being installed."
+            )
+
         out_queue = Queue()
 
         nanshe.box.spams_sandbox.run_multiprocessing_queue_spams_trainDL(
@@ -268,6 +298,11 @@ class TestSpamsSandbox(object):
         assert (self.g3.astype(bool) == d3.astype(bool)).all()
 
     def test_call_multiprocessing_queue_spams_trainDL_1(self):
+        if not has_spams:
+            raise nose.SkipTest(
+                "Cannot run this test without SPAMS being installed."
+            )
+
         d = nanshe.box.spams_sandbox.call_multiprocessing_queue_spams_trainDL(
             self.g.astype(float),
             **{
@@ -314,6 +349,11 @@ class TestSpamsSandbox(object):
 
     @nose.plugins.attrib.attr("3D")
     def test_call_multiprocessing_queue_spams_trainDL_2(self):
+        if not has_spams:
+            raise nose.SkipTest(
+                "Cannot run this test without SPAMS being installed."
+            )
+
         d3 = nanshe.box.spams_sandbox.call_multiprocessing_queue_spams_trainDL(
             self.g3.astype(float),
             **{
@@ -359,6 +399,11 @@ class TestSpamsSandbox(object):
         assert (len(unmatched_g3) == 0)
 
     def test_call_multiprocessing_queue_spams_trainDL_3(self):
+        if not has_spams:
+            raise nose.SkipTest(
+                "Cannot run this test without SPAMS being installed."
+            )
+
         d = nanshe.box.spams_sandbox.call_multiprocessing_queue_spams_trainDL(
             self.g.astype(float),
             D=self.g.astype(float),
@@ -407,6 +452,11 @@ class TestSpamsSandbox(object):
 
     @nose.plugins.attrib.attr("3D")
     def test_call_multiprocessing_queue_spams_trainDL_4(self):
+        if not has_spams:
+            raise nose.SkipTest(
+                "Cannot run this test without SPAMS being installed."
+            )
+
         d3 = nanshe.box.spams_sandbox.call_multiprocessing_queue_spams_trainDL(
             self.g3.astype(float),
             D=self.g3.astype(float),
@@ -454,6 +504,11 @@ class TestSpamsSandbox(object):
         assert (self.g3.astype(bool) == d3.astype(bool)).all()
 
     def test_run_multiprocessing_array_spams_trainDL_1(self):
+        if not has_spams:
+            raise nose.SkipTest(
+                "Cannot run this test without SPAMS being installed."
+            )
+
         float_type = numpy.float64
 
         g_array_type = numpy.ctypeslib.ndpointer(
@@ -545,6 +600,11 @@ class TestSpamsSandbox(object):
 
     @nose.plugins.attrib.attr("3D")
     def test_run_multiprocessing_array_spams_trainDL_2(self):
+        if not has_spams:
+            raise nose.SkipTest(
+                "Cannot run this test without SPAMS being installed."
+            )
+
         float_type = numpy.float64
 
         g3_array_type = numpy.ctypeslib.ndpointer(
@@ -635,6 +695,11 @@ class TestSpamsSandbox(object):
         assert (len(unmatched_g3) == 0)
 
     def test_call_multiprocessing_array_spams_trainDL_1(self):
+        if not has_spams:
+            raise nose.SkipTest(
+                "Cannot run this test without SPAMS being installed."
+            )
+
         d = nanshe.box.spams_sandbox.call_multiprocessing_array_spams_trainDL(
             self.g.astype(float),
             **{
@@ -681,6 +746,11 @@ class TestSpamsSandbox(object):
 
     @nose.plugins.attrib.attr("3D")
     def test_call_multiprocessing_array_spams_trainDL_2(self):
+        if not has_spams:
+            raise nose.SkipTest(
+                "Cannot run this test without SPAMS being installed."
+            )
+
         d3 = nanshe.box.spams_sandbox.call_multiprocessing_array_spams_trainDL(
             self.g3.astype(float),
             **{
@@ -726,6 +796,11 @@ class TestSpamsSandbox(object):
         assert (len(unmatched_g3) == 0)
 
     def test_run_multiprocessing_array_spams_trainDL_3(self):
+        if not has_spams:
+            raise nose.SkipTest(
+                "Cannot run this test without SPAMS being installed."
+            )
+
         float_type = numpy.float64
 
         g_array_type = numpy.ctypeslib.ndpointer(
@@ -821,6 +896,11 @@ class TestSpamsSandbox(object):
 
     @nose.plugins.attrib.attr("3D")
     def test_run_multiprocessing_array_spams_trainDL_4(self):
+        if not has_spams:
+            raise nose.SkipTest(
+                "Cannot run this test without SPAMS being installed."
+            )
+
         float_type = numpy.float64
 
         g3_array_type = numpy.ctypeslib.ndpointer(
@@ -915,6 +995,11 @@ class TestSpamsSandbox(object):
         assert (self.g3.astype(bool) == d3.astype(bool)).all()
 
     def test_call_spams_trainDL_1(self):
+        if not has_spams:
+            raise nose.SkipTest(
+                "Cannot run this test without SPAMS being installed."
+            )
+
         d = nanshe.box.spams_sandbox.call_spams_trainDL(
             self.g.astype(float),
             **{
@@ -961,6 +1046,11 @@ class TestSpamsSandbox(object):
 
     @nose.plugins.attrib.attr("3D")
     def test_call_spams_trainDL_2(self):
+        if not has_spams:
+            raise nose.SkipTest(
+                "Cannot run this test without SPAMS being installed."
+            )
+
         d3 = nanshe.box.spams_sandbox.call_spams_trainDL(
             self.g3.astype(float),
             **{
@@ -1006,6 +1096,11 @@ class TestSpamsSandbox(object):
         assert (len(unmatched_g3) == 0)
 
     def test_call_spams_trainDL_3(self):
+        if not has_spams:
+            raise nose.SkipTest(
+                "Cannot run this test without SPAMS being installed."
+            )
+
         d = nanshe.box.spams_sandbox.call_spams_trainDL(
             self.g.astype(float),
             D=self.g.astype(float),
@@ -1054,6 +1149,11 @@ class TestSpamsSandbox(object):
 
     @nose.plugins.attrib.attr("3D")
     def test_call_spams_trainDL_4(self):
+        if not has_spams:
+            raise nose.SkipTest(
+                "Cannot run this test without SPAMS being installed."
+            )
+
         d3 = nanshe.box.spams_sandbox.call_spams_trainDL(
             self.g3.astype(float),
             D=self.g3.astype(float),

--- a/tests/test_nanshe/test_imp/test_segment.py
+++ b/tests/test_nanshe/test_imp/test_segment.py
@@ -5,6 +5,8 @@ __author__ = "John Kirkham <kirkhamj@janelia.hhmi.org>"
 __date__ = "$Jul 30, 2014 19:35:11 EDT$"
 
 
+import imp
+
 import nose
 import nose.plugins
 import nose.plugins.attrib
@@ -23,6 +25,14 @@ import nanshe.util.xnumpy
 import nanshe.imp.segment
 
 import nanshe.syn.data
+
+
+has_spams = False
+try:
+    imp.find_module("spams")
+    has_spams = True
+except ImportError:
+    pass
 
 
 class TestSegment(object):
@@ -817,6 +827,11 @@ class TestSegment(object):
         nanshe.imp.segment.preprocess_data(image_stack, **config)
 
     def test_generate_dictionary_00(self):
+        if not has_spams:
+            raise nose.SkipTest(
+                "Cannot run this test with SPAMS being installed"
+            )
+
         p = numpy.array([[27, 51],
                          [66, 85],
                          [77, 45]])
@@ -870,6 +885,11 @@ class TestSegment(object):
         assert (len(unmatched_g) == 0)
 
     def test_generate_dictionary_01(self):
+        if not has_spams:
+            raise nose.SkipTest(
+                "Cannot run this test with SPAMS being installed"
+            )
+
         p = numpy.array([[27, 51],
                          [66, 85],
                          [77, 45]])
@@ -924,6 +944,11 @@ class TestSegment(object):
 
     @nose.plugins.attrib.attr("3D")
     def test_generate_dictionary_02(self):
+        if not has_spams:
+            raise nose.SkipTest(
+                "Cannot run this test with SPAMS being installed"
+            )
+
         p = numpy.array([[27, 51, 87],
                          [66, 85, 55],
                          [77, 45, 26]])
@@ -978,6 +1003,11 @@ class TestSegment(object):
 
     @nose.plugins.attrib.attr("3D")
     def test_generate_dictionary_03(self):
+        if not has_spams:
+            raise nose.SkipTest(
+                "Cannot run this test with SPAMS being installed"
+            )
+
         p = numpy.array([[27, 51, 87],
                          [66, 85, 55],
                          [77, 45, 26]])
@@ -1031,6 +1061,11 @@ class TestSegment(object):
         assert (len(unmatched_g) == 0)
 
     def test_generate_dictionary_04(self):
+        if not has_spams:
+            raise nose.SkipTest(
+                "Cannot run this test with SPAMS being installed"
+            )
+
         p = numpy.array([[27, 51],
                          [66, 85],
                          [77, 45]])
@@ -1087,6 +1122,11 @@ class TestSegment(object):
         assert (g.astype(bool) == d.astype(bool)).all()
 
     def test_generate_dictionary_05(self):
+        if not has_spams:
+            raise nose.SkipTest(
+                "Cannot run this test with SPAMS being installed"
+            )
+
         p = numpy.array([[27, 51],
                          [66, 85],
                          [77, 45]])
@@ -1144,6 +1184,11 @@ class TestSegment(object):
 
     @nose.plugins.attrib.attr("3D")
     def test_generate_dictionary_06(self):
+        if not has_spams:
+            raise nose.SkipTest(
+                "Cannot run this test with SPAMS being installed"
+            )
+
         p = numpy.array([[27, 51, 87],
                          [66, 85, 55],
                          [77, 45, 26]])
@@ -1201,6 +1246,11 @@ class TestSegment(object):
 
     @nose.plugins.attrib.attr("3D")
     def test_generate_dictionary_07(self):
+        if not has_spams:
+            raise nose.SkipTest(
+                "Cannot run this test with SPAMS being installed"
+            )
+
         p = numpy.array([[27, 51, 87],
                          [66, 85, 55],
                          [77, 45, 26]])

--- a/tests/test_nanshe/test_learner.py
+++ b/tests/test_nanshe/test_learner.py
@@ -104,20 +104,12 @@ def setup_2d(a_callable):
                 }
             },
             "generate_dictionary" : {
-                "spams.trainDL" : {
-                    "gamma2" : 0,
-                    "gamma1" : 0,
-                    "numThreads" : 1,
-                    "K" : 10,
-                    "iter" : 100,
-                    "modeD" : 0,
-                    "posAlpha" : True,
-                    "clean" : True,
-                    "posD" : True,
-                    "batchsize" : 256,
-                    "lambda1" : 0.2,
-                    "lambda2" : 0,
-                    "mode" : 2
+                "sklearn.decomposition.dict_learning_online" : {
+                    "n_jobs" : 1,
+                    "n_components" : 10,
+                    "n_iter" : 100,
+                    "batch_size" : 256,
+                    "alpha" : 0.2
                 }
             }
         }
@@ -544,20 +536,12 @@ def setup_3d(a_callable):
                 }
             },
             "generate_dictionary" : {
-                "spams.trainDL" : {
-                    "gamma2" : 0,
-                    "gamma1" : 0,
-                    "numThreads" : 1,
-                    "K" : 10,
-                    "iter" : 100,
-                    "modeD" : 0,
-                    "posAlpha" : True,
-                    "clean" : True,
-                    "posD" : True,
-                    "batchsize" : 256,
-                    "lambda1" : 0.2,
-                    "lambda2" : 0,
-                    "mode" : 2
+                "sklearn.decomposition.dict_learning_online" : {
+                    "n_jobs" : 1,
+                    "n_components" : 10,
+                    "n_iter" : 100,
+                    "batch_size" : 256,
+                    "alpha" : 0.2
                 }
             }
         }

--- a/tests/test_nanshe/test_learner.py
+++ b/tests/test_nanshe/test_learner.py
@@ -6,6 +6,7 @@ import nose
 import nose.plugins
 import nose.plugins.attrib
 
+import imp
 import json
 import operator
 import os
@@ -23,6 +24,14 @@ import nanshe.io.hdf5.record
 import nanshe.syn.data
 
 import nanshe.learner
+
+
+has_spams = False
+try:
+    imp.find_module("spams")
+    has_spams = True
+except ImportError:
+    pass
 
 
 def setup_2d(a_callable):
@@ -896,6 +905,11 @@ def test_main_1():
 
 @nanshe.util.wrappers.with_setup_state(setup_2d, teardown_2d)
 def test_main_2():
+    if not has_spams:
+        raise nose.SkipTest(
+            "Cannot run this test with SPAMS being installed"
+        )
+
     executable = os.path.splitext(nanshe.learner.__file__)[0] + os.extsep + "py"
 
     argv = (executable, test_main_2.config_blocks_filename, test_main_2.hdf5_input_filepath, test_main_2.hdf5_output_filepath,)
@@ -942,6 +956,11 @@ def test_main_2():
 @nose.plugins.attrib.attr("DRMAA")
 @nanshe.util.wrappers.with_setup_state(setup_2d, teardown_2d)
 def test_main_3():
+    if not has_spams:
+        raise nose.SkipTest(
+            "Cannot run this test with SPAMS being installed"
+        )
+
     # Attempt to import drmaa.
     # If it fails to import, either the user has no intent in using it or forgot to install it.
     # If it imports, but fails to find symbols, then the user has not set DRMAA_LIBRARY_PATH or does not have libdrmaa.so.
@@ -1046,6 +1065,11 @@ def test_main_4():
 @nose.plugins.attrib.attr("3D")
 @nanshe.util.wrappers.with_setup_state(setup_3d, teardown_3d)
 def test_main_5():
+    if not has_spams:
+        raise nose.SkipTest(
+            "Cannot run this test with SPAMS being installed"
+        )
+
     executable = os.path.splitext(nanshe.learner.__file__)[0] + os.extsep + "py"
 
     argv = (executable, test_main_5.config_blocks_3D_filename, test_main_5.hdf5_input_3D_filepath, test_main_5.hdf5_output_3D_filepath,)
@@ -1092,6 +1116,11 @@ def test_main_5():
 @nose.plugins.attrib.attr("3D", "DRMAA")
 @nanshe.util.wrappers.with_setup_state(setup_3d, teardown_3d)
 def test_main_6():
+    if not has_spams:
+        raise nose.SkipTest(
+            "Cannot run this test with SPAMS being installed"
+        )
+
     # Attempt to import drmaa.
     # If it fails to import, either the user has no intent in using it or forgot to install it.
     # If it imports, but fails to find symbols, then the user has not set DRMAA_LIBRARY_PATH or does not have libdrmaa.so.
@@ -1190,6 +1219,11 @@ def test_generate_neurons_io_handler_1():
 
 @nanshe.util.wrappers.with_setup_state(setup_2d, teardown_2d)
 def test_generate_neurons_io_handler_2():
+    if not has_spams:
+        raise nose.SkipTest(
+            "Cannot run this test with SPAMS being installed"
+        )
+
     nanshe.learner.generate_neurons_io_handler(test_generate_neurons_io_handler_2.hdf5_input_filepath, test_generate_neurons_io_handler_2.hdf5_output_filepath, test_generate_neurons_io_handler_2.config_blocks_filename)
 
     assert os.path.exists(test_generate_neurons_io_handler_2.hdf5_output_filename)
@@ -1232,6 +1266,11 @@ def test_generate_neurons_io_handler_2():
 @nose.plugins.attrib.attr("DRMAA")
 @nanshe.util.wrappers.with_setup_state(setup_2d, teardown_2d)
 def test_generate_neurons_io_handler_3():
+    if not has_spams:
+        raise nose.SkipTest(
+            "Cannot run this test with SPAMS being installed"
+        )
+
     # Attempt to import drmaa.
     # If it fails to import, either the user has no intent in using it or forgot to install it.
     # If it imports, but fails to find symbols, then the user has not set DRMAA_LIBRARY_PATH or does not have libdrmaa.so.
@@ -1328,6 +1367,11 @@ def test_generate_neurons_io_handler_4():
 @nose.plugins.attrib.attr("3D")
 @nanshe.util.wrappers.with_setup_state(setup_3d, teardown_3d)
 def test_generate_neurons_io_handler_5():
+    if not has_spams:
+        raise nose.SkipTest(
+            "Cannot run this test with SPAMS being installed"
+        )
+
     nanshe.learner.generate_neurons_io_handler(test_generate_neurons_io_handler_5.hdf5_input_3D_filepath, test_generate_neurons_io_handler_5.hdf5_output_3D_filepath, test_generate_neurons_io_handler_5.config_blocks_3D_filename)
 
     assert os.path.exists(test_generate_neurons_io_handler_5.hdf5_output_3D_filename)
@@ -1370,6 +1414,11 @@ def test_generate_neurons_io_handler_5():
 @nose.plugins.attrib.attr("3D", "DRMAA")
 @nanshe.util.wrappers.with_setup_state(setup_3d, teardown_3d)
 def test_generate_neurons_io_handler_6():
+    if not has_spams:
+        raise nose.SkipTest(
+            "Cannot run this test with SPAMS being installed"
+        )
+
     # Attempt to import drmaa.
     # If it fails to import, either the user has no intent in using it or forgot to install it.
     # If it imports, but fails to find symbols, then the user has not set DRMAA_LIBRARY_PATH or does not have libdrmaa.so.
@@ -1506,6 +1555,11 @@ def test_generate_neurons_a_block_2():
 
 @nanshe.util.wrappers.with_setup_state(setup_2d, teardown_2d)
 def test_generate_neurons_blocks_1():
+    if not has_spams:
+        raise nose.SkipTest(
+            "Cannot run this test with SPAMS being installed"
+        )
+
     nanshe.learner.generate_neurons_blocks(test_generate_neurons_blocks_1.hdf5_input_filepath, test_generate_neurons_blocks_1.hdf5_output_filepath, **test_generate_neurons_blocks_1.config_blocks["generate_neurons_blocks"])
 
     assert os.path.exists(test_generate_neurons_blocks_1.hdf5_output_filename)
@@ -1548,6 +1602,11 @@ def test_generate_neurons_blocks_1():
 @nose.plugins.attrib.attr("DRMAA")
 @nanshe.util.wrappers.with_setup_state(setup_2d, teardown_2d)
 def test_generate_neurons_blocks_2():
+    if not has_spams:
+        raise nose.SkipTest(
+            "Cannot run this test with SPAMS being installed"
+        )
+
     # Attempt to import drmaa.
     # If it fails to import, either the user has no intent in using it or forgot to install it.
     # If it imports, but fails to find symbols, then the user has not set DRMAA_LIBRARY_PATH or does not have libdrmaa.so.
@@ -1602,6 +1661,11 @@ def test_generate_neurons_blocks_2():
 @nose.plugins.attrib.attr("3D")
 @nanshe.util.wrappers.with_setup_state(setup_3d, teardown_3d)
 def test_generate_neurons_blocks_3():
+    if not has_spams:
+        raise nose.SkipTest(
+            "Cannot run this test with SPAMS being installed"
+        )
+
     nanshe.learner.generate_neurons_blocks(test_generate_neurons_blocks_3.hdf5_input_3D_filepath, test_generate_neurons_blocks_3.hdf5_output_3D_filepath, **test_generate_neurons_blocks_3.config_blocks_3D["generate_neurons_blocks"])
 
     assert os.path.exists(test_generate_neurons_blocks_3.hdf5_output_3D_filename)
@@ -1644,6 +1708,11 @@ def test_generate_neurons_blocks_3():
 @nose.plugins.attrib.attr("3D", "DRMAA")
 @nanshe.util.wrappers.with_setup_state(setup_3d, teardown_3d)
 def test_generate_neurons_blocks_4():
+    if not has_spams:
+        raise nose.SkipTest(
+            "Cannot run this test with SPAMS being installed"
+        )
+
     # Attempt to import drmaa.
     # If it fails to import, either the user has no intent in using it or forgot to install it.
     # If it imports, but fails to find symbols, then the user has not set DRMAA_LIBRARY_PATH or does not have libdrmaa.so.

--- a/tests/test_nanshe/test_viewer.py
+++ b/tests/test_nanshe/test_viewer.py
@@ -2,4 +2,9 @@ __author__ = "John Kirkham <kirkhamj@janelia.hhmi.org>"
 __date__ = "$Mar 18, 2015 22:25:20 EDT$"
 
 
-import nanshe.viewer
+from sys import version_info
+
+if version_info < (3,):
+    import nanshe.viewer
+
+del version_info


### PR DESCRIPTION
In order to get a working version of CI for Python 3.x, so as not to lose the functionality that we have gained, this tries to test what is possible with a current version of `scikit-learn`. This means that there is still use of SPAMS in some cases (so tests that will not run on Python 3.x). Also, the viewer is not tested and (once fixed) will not even be imported on Python 3.x as there is no Python 3.x support in Volumina. However, as those code paths are largely stagnant (with the exception of any Python 3.x changes made), this is acceptable at present. In the long term, we will want to regain coverage of these code paths in our test suite. Though that should not hold us back from getting CI with Python 3.x now.