### PR TITLE
Cast to types explicitly in region properties

### DIFF
--- a/nanshe/imp/segment.py
+++ b/nanshe/imp/segment.py
@@ -1160,10 +1160,13 @@ def region_properties_scikit_image(new_label_image, *args, **kwargs):
             for each_key in properties:
                 if each_key in array_properties:
                     new_label_image_props_with_arrays[i][each_key] = numpy.array(
-                        new_label_image_props[i][each_key]
+                        new_label_image_props[i][each_key],
+                        dtype=region_properties_type_dict[each_key]
                     )
                 else:
-                    new_label_image_props_with_arrays[i][each_key] = new_label_image_props[i][each_key]
+                    new_label_image_props_with_arrays[i][each_key] = region_properties_type_dict[each_key](
+                        new_label_image_props[i][each_key]
+                    )
 
         # Holds the values from props.
         new_label_image_props_with_arrays_values = []


### PR DESCRIPTION
In scikit-image 0.12.0 some region properties values have changed types. For instance, area is now an integer. To remain backwards compatible, we cast everything to the type expected so as to match. In other words, area will still be a double precision float when using scikit-image 0.12.0.