### PR TITLE
Skip `setup.py` during testing

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ verbosity=3
 with-doctest=1
 doctest-tests=1
 with-coverage=1
-ignore-files=viewer.py
+ignore-files=setup.py|viewer.py
 [build_sphinx]
 builder=html
 [versioneer]


### PR DESCRIPTION
Without this modification, running `nosetests` fails as it attempts to test `setup.py`.