### PR TITLE
Convert result `numpy.product` (Pt. 2)

### DIFF
--- a/nanshe/box/spams_sandbox.py
+++ b/nanshe/box/spams_sandbox.py
@@ -331,7 +331,7 @@ def call_multiprocessing_array_spams_trainDL(X, *args, **kwargs):
     # Create a shared array to contain the result
     result_array = multiprocessing.Array(
         result_array_ctype,
-        numpy.product(result_array_type._shape_),
+        int(numpy.product(result_array_type._shape_)),
         lock=False
     )
 


### PR DESCRIPTION
Missed another `numpy.product` that needed conversion to `int`. This fixes it.

xref: https://github.com/nanshe-org/nanshe/pull/387