### PR TITLE
Remove Qt dependency

### DIFF
--- a/nanshe/util/prof.py
+++ b/nanshe/util/prof.py
@@ -7,9 +7,8 @@ Overview
 The module ``prof`` provides a few primitives for tracing function calls and
 memory usage. In particular, it provides a trace logger that gives us feedback
 about arguments passed, the run time, the exception raised, etc. Decorators are
-available for wrapping functions and classes (all methods). The special case of
-``Qt`` inheriting classes is handled by a separate decorator. In addition to
-the trace logger, a memory profiler is also provided, which can be run in a
+available for wrapping functions and classes (all methods). In addition to the
+trace logger, a memory profiler is also provided, which can be run in a
 separate thread to get information about memory usage. The memory profiler
 requires |psutil|_.
 
@@ -312,62 +311,6 @@ def log_class(logger,
     """
 
     return(wrappers.class_decorate_all_methods(log_call(
-        logger,
-        to_log_call=to_log_call,
-        to_print_args=to_print_args,
-        to_print_time=to_print_time,
-        to_print_exception=to_print_exception
-    )))
-
-
-def qt_log_class(logger,
-                 to_log_call=True,
-                 to_print_args=False,
-                 to_print_time=True,
-                 to_print_exception=False):
-    """
-        Takes a given logger and uses it to log entering and leaving all
-        methods of the decorated class. Intended to be used as a decorator that
-        takes a few arguments.
-
-        Args:
-            logger(Logger):                Used for logging entry, exit and
-                                           possibly arguments.
-
-        Keyword Args:
-            to_log_call(bool):             Whether to log call or not. This
-                                           overrides all other arguments. It
-                                           will be stored as a global variable
-                                           on the methods, which can be changed
-                                           at runtime.
-
-            to_print_args(bool):           Whether to output the arguments and
-                                           keyword arguments passed to the
-                                           function. This should not
-                                           automatically be true as some
-                                           arguments may not be printable or
-                                           may be expensive to print. Thus, it
-                                           should be up to the developer to use
-                                           their own discretion. Further, we
-                                           don't want to break their existing
-                                           code. It will be stored as a global
-                                           variable on the methods, which can
-                                           be changed at runtime.
-
-            to_print_time(bool):           Prints the time it took to run the
-                                           wrapped callable.
-
-            to_print_exception(bool):      Whether to print the traceback when
-                                           an exception is raise. It will be
-                                           stored as a global variable on the
-                                           methods, which can be changed at
-                                           runtime.
-
-        Returns:
-            log_call_decorator(for wrapping)
-    """
-
-    return(wrappers.qt_class_decorate_all_methods(log_call(
         logger,
         to_log_call=to_log_call,
         to_print_args=to_print_args,

--- a/nanshe/util/wrappers.py
+++ b/nanshe/util/wrappers.py
@@ -9,9 +9,7 @@ particular, it is ensured all wrapped functions contain an attribute
 ``__wrapped__``, which points back to the original function before the wrapper
 was applied. Also, the ability to wrap classes with a decorator to apply a
 ``metaclass`` or series of ``metaclass``es is provided. Making it much easier
-to transform classes without mucking in their internals. For classes inheriting
-from ``Qt`` objects a special decorator is provided to make sure they
-participate in the correct inheritance scheme.
+to transform classes without mucking in their internals.
 
 .. |functools| replace:: ``functools``
 .. _functools: http://docs.python.org/2/library/functools.html
@@ -30,8 +28,6 @@ import collections
 import inspect
 import functools
 import types
-
-import PyQt4.QtCore
 
 
 def update_wrapper(wrapper,
@@ -302,44 +298,6 @@ def class_decorate_all_methods(*decorators):
         """
             Metaclass, which decorates all methods with the list of decorators
             in order.
-        """
-
-        def __new__(meta, name, bases, dct):
-            for _k, _v in dct.items():
-                # Are all of FunctionType at this point.
-                # Will be of MethodType at a later step.
-                if isinstance(_v, types.FunctionType):
-                    for each_decorator in decorators:
-                        _v = each_decorator(_v)
-
-                dct[_k] = _v
-
-            return(super(MetaAllMethodsDecorator, meta).__new__(
-                meta, name, bases, dct
-            ))
-
-    return(metaclass(MetaAllMethodsDecorator))
-
-
-def qt_class_decorate_all_methods(*decorators):
-    """
-        Returns a decorator that decorates a class such that all its methods
-        are decorated by the decorators provided.
-
-        Args:
-            *decorators(tuple):     decorators to decorate all methods with.
-
-        Returns:
-            (decorator):            a decorator for the class.
-    """
-
-    class MetaAllMethodsDecorator(PyQt4.QtCore.pyqtWrapperType):
-        """
-            Metaclass, which decorates all methods with the list of decorators
-            in order.
-
-            Inherits from PyQt4.QtCore.pyqtWrapperType based on this
-            ( http://www.gulon.co.uk/2012/12/28/pyqt4-qobjects-and-metaclasses/ ).
         """
 
         def __new__(meta, name, bases, dct):

--- a/tests/test_nanshe/test_util/test_wrappers.py
+++ b/tests/test_nanshe/test_util/test_wrappers.py
@@ -8,9 +8,6 @@ __date__ = "$Mar 25, 2015 13:30:52 EDT$"
 import functools
 import sys
 
-import PyQt4
-import PyQt4.QtCore
-
 import nanshe.util.wrappers
 
 
@@ -201,32 +198,6 @@ class TestWrappers(object):
                 pass
 
         ClassWrapped = nanshe.util.wrappers.class_decorate_all_methods(
-            nanshe.util.wrappers.identity_wrapper
-        )(Class)
-
-        assert ClassWrapped != Class
-        assert not hasattr(Class, "__wrapped__")
-        assert hasattr(ClassWrapped, "__wrapped__")
-        assert ClassWrapped.__wrapped__ == Class
-
-        assert ClassWrapped.__init__ != Class.__init__
-        assert not hasattr(Class.__init__, "__wrapped__")
-        assert hasattr(ClassWrapped.__init__, "__wrapped__")
-
-        if sys.version_info.major < 3:
-            assert ClassWrapped.__init__.__wrapped__ != Class.__init__
-        else:
-            assert ClassWrapped.__init__.__wrapped__ == Class.__init__
-
-        assert ClassWrapped.__wrapped__.__init__ == Class.__init__
-
-
-    def test_qt_class_decorate_all_methods(self):
-        class Class(PyQt4.QtCore.QObject):
-            def __init__(self):
-                pass
-
-        ClassWrapped = nanshe.util.wrappers.qt_class_decorate_all_methods(
             nanshe.util.wrappers.identity_wrapper
         )(Class)
 


### PR DESCRIPTION
As the viewer has now been removed, we don't have any need for Qt/PyQt or any functionality provided to handle Qt/PyQt. Thus this removes that code. It may latter be broken out as its own package or as an optional part or generalization of existing code (without a Qt dependency) in another library.

xref: https://github.com/nanshe-org/nanshe/pull/394