### PR TITLE
Pin `conda-build` to version 1.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ install:
    - echo "python ${PYTHON_VERSION}.*" >> $HOME/miniconda/conda-meta/pinned
    - conda install python=$PYTHON_VERSION
    # Install basic conda dependencies.
+   - echo "conda-build 1.*" >> $HOME/miniconda/conda-meta/pinned
    - conda install conda-build
    # Build the conda package for nanshe.
    - cd $TRAVIS_REPO_SLUG


### PR DESCRIPTION
This pins `conda-build` to version `1.x`. Have noticed some issues ( https://github.com/conda/conda-build/issues/1305 ) with `bdist_conda` that are going to cause us pain. So this should help us avoid them until they get sorted.