### PR TITLE
Prep vendoring dependencies

### DIFF
--- a/.wercker.yml
+++ b/.wercker.yml
@@ -5,6 +5,7 @@ build:
             name: Ensure clean repo.
             code: |-
                 git update-index -q --refresh
+                git submodule update --init --recursive
 
         - script:
             name: Build Conda Package.

--- a/nanshe/vendored/__init__.py
+++ b/nanshe/vendored/__init__.py
@@ -1,0 +1,17 @@
+"""
+This package exists to provided vendored copies of libraries.
+
+===============================================================================
+Overview
+===============================================================================
+The ``vendored`` package exists to hold git submodules for various dependencies
+that have since been refactored out of this library or written from scratch and
+added as dependencies. This is not intended to exist for the long term.
+"""
+
+
+__author__ = "John Kirkham <kirkhamj@janelia.hhmi.org>"
+__date__ = "$Sep 06, 2016 09:57:10 EDT$"
+
+__all__ = [
+]


### PR DESCRIPTION
This is all preparation for vendoring all the dependencies. Basically this is a temporary measure to hold us over until we can actually package these dependencies.