### PR TITLE
vendored -> _vendor

### DIFF
--- a/nanshe/_vendor/__init__.py
+++ b/nanshe/_vendor/__init__.py
@@ -4,7 +4,7 @@ This package exists to provided vendored copies of libraries.
 ===============================================================================
 Overview
 ===============================================================================
-The ``vendored`` package exists to hold git submodules for various dependencies
+The ``_vendor`` package exists to hold git submodules for various dependencies
 that have since been refactored out of this library or written from scratch and
 added as dependencies. This is not intended to exist for the long term.
 """


### PR DESCRIPTION
Tweaks what was done in PR ( https://github.com/nanshe-org/nanshe/pull/402 ). Renamed as it should be a private package. Also mimics what `conda` [does]( https://github.com/conda/conda/tree/9c88776d2779b2cf04978182420e500335dd7072/conda/_vendor ) for this problem.