### PR TITLE
Adjust coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -15,7 +15,6 @@ exclude_lines =
 omit =
     */python?.?/*
     */site-packages/*
-    */ilastik/*
     *tests/*
     */versioneer.py
     */_version.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -18,3 +18,4 @@ omit =
     *tests/*
     */versioneer.py
     */_version.py
+    */_vendor/*


### PR DESCRIPTION
* Drops the last vestige of ilastik. ( https://github.com/nanshe-org/nanshe/pull/394 )
* Exclude the `_vendor` directory from test coverage. ( https://github.com/nanshe-org/nanshe/pull/405 ) ( https://github.com/nanshe-org/nanshe/pull/402 )