### PR TITLE
Unpin `sphinx`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,6 @@ install:
    - export DRMAA_LIBRARY_PATH=/usr/lib/libdrmaa.so.1.0
    - conda install drmaa
    # Install sphinx 1.3 and friends to build documentation.
-   - echo "sphinx 1.3.*" >> $HOME/miniconda/envs/testenv/conda-meta/pinned
    - conda install sphinx
    - conda install cloud_sptheme
    # Install coverage and coveralls to generate and submit test coverage results for coveralls.io.


### PR DESCRIPTION
Unpinning `sphinx` as any reasonably recent version now works.