### PR TITLE
Use `npctypes` for some utility functions

### DIFF
--- a/nanshe/util/xnumpy.py
+++ b/nanshe/util/xnumpy.py
@@ -43,6 +43,8 @@ import mahotas
 
 import vigra
 
+from npctypes.types import tinfo as info
+from npctypes.types import ctype as to_ctype
 
 from nanshe.util import iters
 
@@ -53,76 +55,6 @@ from nanshe.util import prof
 
 # Get the logger
 trace_logger = prof.getTraceLogger(__name__)
-
-
-@prof.log_call(trace_logger)
-def info(a_type):
-    """
-        Takes a ``numpy.dtype`` or any type that can be converted to a
-        ``numpy.dtype`` and returns its info.
-
-        Args:
-            a_type(type):                  the type to find info for.
-
-        Returns:
-            (np.core.getlimits.info):      info about the type.
-
-        Examples:
-            >>> info(float)
-            finfo(resolution=1e-15, min=-1.7976931348623157e+308, max=1.7976931348623157e+308, dtype=float64)
-
-            >>> info(numpy.float64)
-            finfo(resolution=1e-15, min=-1.7976931348623157e+308, max=1.7976931348623157e+308, dtype=float64)
-
-            >>> info(numpy.float32)
-            finfo(resolution=1e-06, min=-3.4028235e+38, max=3.4028235e+38, dtype=float32)
-
-            >>> info(complex)
-            finfo(resolution=1e-15, min=-1.7976931348623157e+308, max=1.7976931348623157e+308, dtype=float64)
-
-            >>> info(int)
-            iinfo(min=-9223372036854775808, max=9223372036854775807, dtype=int64)
-    """
-
-    a_type = numpy.dtype(a_type).type
-
-    if issubclass(a_type, numpy.integer):
-        return(numpy.iinfo(a_type))
-    else:
-        return(numpy.finfo(a_type))
-
-
-@prof.log_call(trace_logger)
-def to_ctype(a_type):
-    """
-        Takes a numpy.dtype or any type that can be converted to a numpy.dtype
-        and returns its equivalent ctype.
-
-        Args:
-            a_type(type):      the type to find an equivalent ctype to.
-
-        Returns:
-            (ctype):           the ctype equivalent to the dtype provided.
-
-        Examples:
-            >>> to_ctype(float)
-            <class 'ctypes.c_double'>
-
-            >>> to_ctype(numpy.float64)
-            <class 'ctypes.c_double'>
-
-            >>> to_ctype(numpy.float32)
-            <class 'ctypes.c_float'>
-
-            >>> to_ctype(numpy.dtype(numpy.float32))
-            <class 'ctypes.c_float'>
-
-            >>> to_ctype(int)
-            <class 'ctypes.c_long'>
-    """
-
-    return(type(numpy.ctypeslib.as_ctypes(numpy.array(0, dtype=a_type))))
-
 
 
 @prof.log_call(trace_logger)


### PR DESCRIPTION
Switch to using `npctypes` for some utility functions. Thus dropping our internal versions of them.