### PR TITLE
Absolute import of `npctypes`

### DIFF
--- a/nanshe/util/xnumpy.py
+++ b/nanshe/util/xnumpy.py
@@ -43,6 +43,8 @@ import mahotas
 
 import vigra
 
+import npctypes
+import npctypes.types
 from npctypes.types import tinfo as info
 from npctypes.types import ctype as to_ctype
 


### PR DESCRIPTION
Add absolute imports from `npctypes` to `nanshe.util.xnumpy`.