### PR TITLE
Cleanup `iters`

### DIFF
--- a/nanshe/util/iters.py
+++ b/nanshe/util/iters.py
@@ -142,15 +142,7 @@ def index_enumerator(*sizes):
             [(0, (0, 0)), (1, (0, 1)), (2, (1, 0)), (3, (1, 1)), (4, (2, 0)), (5, (2, 1))]
     """
 
-    # Creates a list of irange generator objects over each respective
-    # dimension of sizes
-    gens = [irange(_) for _ in sizes]
-
-    # Combines the generators to a single generator of indices that go
-    # throughout sizes
-    chain_gen = enumerate(itertools.product(*gens))
-
-    return(chain_gen)
+    return(enumerate(index_generator(*sizes)))
 
 
 @prof.log_call(trace_logger)

--- a/nanshe/util/iters.py
+++ b/nanshe/util/iters.py
@@ -845,8 +845,6 @@ def lagged_generators_zipped(new_iter, n=2, longest=False, fillvalue=None):
                                             values from each iterator.
 
         Examples:
-            >>> isinstance(lagged_generators_zipped(irange(5), 1), izip)
-            True
 
             >>> list(lagged_generators_zipped(irange(5)))
             [(0, 1), (1, 2), (2, 3), (3, 4)]


### PR DESCRIPTION
Does some code cleanup on `iters`. Also simplifies code throughout `iters`.