### PR TITLE
Use future

### DIFF
--- a/nanshe/io/hdf5/serializers.py
+++ b/nanshe/io/hdf5/serializers.py
@@ -29,10 +29,7 @@ from nanshe.util import wrappers
 from nanshe.util import prof
 
 
-try:
-    unicode
-except NameError:
-    unicode = str
+from past.builtins import unicode
 
 
 # Get the logger

--- a/nanshe/io/xjson.py
+++ b/nanshe/io/xjson.py
@@ -26,10 +26,7 @@ __date__ = "$Apr 30, 2014 16:54:30 EDT$"
 from nanshe.util import prof
 
 
-try:
-    unicode
-except NameError:
-    unicode = str
+from past.builtins import unicode
 
 
 # Get the logger

--- a/nanshe/io/xtiff.py
+++ b/nanshe/io/xtiff.py
@@ -44,10 +44,7 @@ except ImportError:
     from skimage.external import tifffile
 
 
-try:
-    unicode
-except NameError:
-    unicode = str
+from past.builtins import unicode
 
 
 # Get the logger

--- a/nanshe/util/iters.py
+++ b/nanshe/util/iters.py
@@ -34,12 +34,12 @@ from kenjutsu.kenjutsu import *
 from nanshe.util import prof
 
 # Import Python 2/3 compatibility functions.
-from yail.core import (
+from builtins import (
     range as irange,
     map as imap,
     zip as izip,
-    zip_longest as izip_longest,
 )
+from future.moves.itertools import zip_longest as izip_longest
 
 # Import replacement functions for compatibility.
 from yail.core import (

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ elif sys.argv[1] == "bdist_conda":
         "blas==1.1",
         "openblas",
         "setuptools",
+        "future",
         "psutil",
         "numpy",
         "scipy",

--- a/tests/test_nanshe/test_box/test_spams_sandbox.py
+++ b/tests/test_nanshe/test_box/test_spams_sandbox.py
@@ -31,10 +31,7 @@ except ImportError:
     pass
 
 
-try:
-    xrange
-except NameError:
-    xrange = range
+from builtins import range as irange
 
 
 class TestSpamsSandbox(object):
@@ -110,7 +107,7 @@ class TestSpamsSandbox(object):
         unmatched_g = range(len(self.g))
         matched = dict()
 
-        for i in xrange(len(d)):
+        for i in irange(len(d)):
             new_unmatched_g = []
             for j in unmatched_g:
                 if not (d[i] == self.g[j]).all():
@@ -166,7 +163,7 @@ class TestSpamsSandbox(object):
         unmatched_g3 = range(len(self.g3))
         matched = dict()
 
-        for i in xrange(len(d3)):
+        for i in irange(len(d3)):
             new_unmatched_g3 = []
             for j in unmatched_g3:
                 if not (d3[i] == self.g3[j]).all():
@@ -221,7 +218,7 @@ class TestSpamsSandbox(object):
         unmatched_g = range(len(self.g))
         matched = dict()
 
-        for i in xrange(len(d)):
+        for i in irange(len(d)):
             new_unmatched_g = []
             for j in unmatched_g:
                 if not (d[i] == self.g[j]).all():
@@ -279,7 +276,7 @@ class TestSpamsSandbox(object):
         unmatched_g3 = range(len(self.g3))
         matched = dict()
 
-        for i in xrange(len(d3)):
+        for i in irange(len(d3)):
             new_unmatched_g3 = []
             for j in unmatched_g3:
                 if not (d3[i] == self.g3[j]).all():
@@ -331,7 +328,7 @@ class TestSpamsSandbox(object):
         unmatched_g = range(len(self.g))
         matched = dict()
 
-        for i in xrange(len(d)):
+        for i in irange(len(d)):
             new_unmatched_g = []
             for j in unmatched_g:
                 if not (d[i] == self.g[j]).all():
@@ -382,7 +379,7 @@ class TestSpamsSandbox(object):
         unmatched_g3 = range(len(self.g3))
         matched = dict()
 
-        for i in xrange(len(d3)):
+        for i in irange(len(d3)):
             new_unmatched_g3 = []
             for j in unmatched_g3:
                 if not (d3[i] == self.g3[j]).all():
@@ -432,7 +429,7 @@ class TestSpamsSandbox(object):
         unmatched_g = range(len(self.g))
         matched = dict()
 
-        for i in xrange(len(d)):
+        for i in irange(len(d)):
             new_unmatched_g = []
             for j in unmatched_g:
                 if not (d[i] == self.g[j]).all():
@@ -485,7 +482,7 @@ class TestSpamsSandbox(object):
         unmatched_g3 = range(len(self.g3))
         matched = dict()
 
-        for i in xrange(len(d3)):
+        for i in irange(len(d3)):
             new_unmatched_g3 = []
             for j in unmatched_g3:
                 if not (d3[i] == self.g3[j]).all():
@@ -552,7 +549,7 @@ class TestSpamsSandbox(object):
         unmatched_g = range(len(self.g))
         matched = dict()
 
-        for i in xrange(len(d)):
+        for i in irange(len(d)):
             new_unmatched_g = []
             for j in unmatched_g:
                 if not (d[i] == self.g[j]).all():
@@ -618,7 +615,7 @@ class TestSpamsSandbox(object):
         unmatched_g3 = range(len(self.g3))
         matched = dict()
 
-        for i in xrange(len(d3)):
+        for i in irange(len(d3)):
             new_unmatched_g3 = []
             for j in unmatched_g3:
                 if not (d3[i] == self.g3[j]).all():
@@ -668,7 +665,7 @@ class TestSpamsSandbox(object):
         unmatched_g = range(len(self.g))
         matched = dict()
 
-        for i in xrange(len(d)):
+        for i in irange(len(d)):
             new_unmatched_g = []
             for j in unmatched_g:
                 if not (d[i] == self.g[j]).all():
@@ -719,7 +716,7 @@ class TestSpamsSandbox(object):
         unmatched_g3 = range(len(self.g3))
         matched = dict()
 
-        for i in xrange(len(d3)):
+        for i in irange(len(d3)):
             new_unmatched_g3 = []
             for j in unmatched_g3:
                 if not (d3[i] == self.g3[j]).all():
@@ -787,7 +784,7 @@ class TestSpamsSandbox(object):
         unmatched_g = range(len(self.g))
         matched = dict()
 
-        for i in xrange(len(d)):
+        for i in irange(len(d)):
             new_unmatched_g = []
             for j in unmatched_g:
                 if not (d[i] == self.g[j]).all():
@@ -857,7 +854,7 @@ class TestSpamsSandbox(object):
         unmatched_g3 = range(len(self.g3))
         matched = dict()
 
-        for i in xrange(len(d3)):
+        for i in irange(len(d3)):
             new_unmatched_g3 = []
             for j in unmatched_g3:
                 if not (d3[i] == self.g3[j]).all():
@@ -909,7 +906,7 @@ class TestSpamsSandbox(object):
         unmatched_g = range(len(self.g))
         matched = dict()
 
-        for i in xrange(len(d)):
+        for i in irange(len(d)):
             new_unmatched_g = []
             for j in unmatched_g:
                 if not (d[i] == self.g[j]).all():
@@ -960,7 +957,7 @@ class TestSpamsSandbox(object):
         unmatched_g3 = range(len(self.g3))
         matched = dict()
 
-        for i in xrange(len(d3)):
+        for i in irange(len(d3)):
             new_unmatched_g3 = []
             for j in unmatched_g3:
                 if not (d3[i] == self.g3[j]).all():
@@ -1010,7 +1007,7 @@ class TestSpamsSandbox(object):
         unmatched_g = range(len(self.g))
         matched = dict()
 
-        for i in xrange(len(d)):
+        for i in irange(len(d)):
             new_unmatched_g = []
             for j in unmatched_g:
                 if not (d[i] == self.g[j]).all():
@@ -1063,7 +1060,7 @@ class TestSpamsSandbox(object):
         unmatched_g3 = range(len(self.g3))
         matched = dict()
 
-        for i in xrange(len(d3)):
+        for i in irange(len(d3)):
             new_unmatched_g3 = []
             for j in unmatched_g3:
                 if not (d3[i] == self.g3[j]).all():

--- a/tests/test_nanshe/test_box/test_spams_sandbox.py
+++ b/tests/test_nanshe/test_box/test_spams_sandbox.py
@@ -13,10 +13,7 @@ import nose.plugins.attrib
 import ctypes
 import multiprocessing
 
-try:
-    from queue import Queue
-except ImportError:
-    from Queue import Queue
+from queue import Queue
 
 import numpy
 import npctypes

--- a/tests/test_nanshe/test_imp/test_registration.py
+++ b/tests/test_nanshe/test_imp/test_registration.py
@@ -17,10 +17,7 @@ import nanshe.io.hdf5.serializers
 import nanshe.imp.registration
 
 
-try:
-    basestring
-except NameError:
-    basestring = str
+from past.builtins import basestring
 
 
 class TestRegisterMeanOffsets(object):

--- a/tests/test_nanshe/test_io/test_xjson.py
+++ b/tests/test_nanshe/test_io/test_xjson.py
@@ -11,10 +11,7 @@ import tempfile
 import nanshe.io.xjson
 
 
-try:
-    unicode
-except NameError:
-    unicode = str
+from past.builtins import unicode
 
 try:
     xrange

--- a/tests/test_nanshe/test_io/test_xjson.py
+++ b/tests/test_nanshe/test_io/test_xjson.py
@@ -13,10 +13,7 @@ import nanshe.io.xjson
 
 from past.builtins import unicode
 
-try:
-    xrange
-except NameError:
-    xrange = range
+from builtins import range as irange
 
 
 class TestXJson(object):
@@ -28,7 +25,7 @@ class TestXJson(object):
         dict_type = dict
 
         params = collections.OrderedDict()
-        params["b"] = list(xrange(3))
+        params["b"] = list(irange(3))
         params["c"] = "test"
         params["a"] = 5
         params["d"] = collections.OrderedDict(params)
@@ -58,7 +55,7 @@ class TestXJson(object):
         dict_type = dict
 
         params = collections.OrderedDict()
-        params["b"] = list(xrange(3))
+        params["b"] = list(irange(3))
         params["b"].append("__comment__ to drop")
         params["c"] = "test"
         params["a"] = 5
@@ -102,7 +99,7 @@ class TestXJson(object):
         dict_type = collections.OrderedDict
 
         params = collections.OrderedDict()
-        params["b"] = list(xrange(3))
+        params["b"] = list(irange(3))
         params["c"] = "test"
         params["a"] = 5
         params["d"] = collections.OrderedDict(params)
@@ -132,7 +129,7 @@ class TestXJson(object):
         dict_type = collections.OrderedDict
 
         params = collections.OrderedDict()
-        params["b"] = list(xrange(3))
+        params["b"] = list(irange(3))
         params["b"].append("__comment__ to drop")
         params["c"] = "test"
         params["a"] = 5

--- a/tests/test_nanshe/test_io/test_xtiff.py
+++ b/tests/test_nanshe/test_io/test_xtiff.py
@@ -22,10 +22,7 @@ import nanshe.io.xtiff
 import nanshe.converter
 
 
-try:
-    unicode
-except NameError:
-    unicode = str
+from past.builtins import unicode
 
 
 class TestXTiff(object):

--- a/tests/test_nanshe/test_util/test_xglob.py
+++ b/tests/test_nanshe/test_util/test_xglob.py
@@ -5,10 +5,7 @@ __date__ = "$Jul 28, 2014 11:50:37 EDT$"
 import nanshe.util.xglob
 
 
-try:
-    xrange
-except NameError:
-    xrange = range
+from builtins import range as irange
 
 
 class TestXGlob(object):
@@ -21,7 +18,7 @@ class TestXGlob(object):
 
         self.temp_files = []
         temp_files_dict = dict()
-        for i in xrange(TestXGlob.num_files):
+        for i in irange(TestXGlob.num_files):
             each_tempfile = tempfile.NamedTemporaryFile(
                 suffix=".tif", dir=self.temp_dir
             )
@@ -45,7 +42,7 @@ class TestXGlob(object):
     def teardown(self):
         import shutil
 
-        for i in xrange(len(self.temp_files)):
+        for i in irange(len(self.temp_files)):
             self.temp_files[i].close()
 
         self.temp_files = []


### PR DESCRIPTION
Try to cutdown on ugly Python 2/3 compatibility hacks by requiring `future` and using it to provide better Python 2/3 compatibility.