### PR TITLE
Fix generate_contour_fast

### DIFF
--- a/nanshe/util/xnumpy.py
+++ b/nanshe/util/xnumpy.py
@@ -4297,12 +4297,12 @@ def generate_contour_fast(a_image):
             >>> a = numpy.array([[ True,  True, False],
             ...                  [False, False, False],
             ...                  [ True,  True,  True]], dtype=bool)
-            >>> generate_contour(a)
+            >>> generate_contour_fast(a)
             array([[ True,  True, False],
                    [False, False, False],
                    [ True,  True,  True]], dtype=bool)
 
-            >>> generate_contour(numpy.eye(3))
+            >>> generate_contour_fast(numpy.eye(3))
             array([[ 1.,  0.,  0.],
                    [ 0.,  1.,  0.],
                    [ 0.,  0.,  1.]])
@@ -4316,7 +4316,7 @@ def generate_contour_fast(a_image):
             ...     [False,  True, False, False, False, False,  True],
             ...     [False,  True,  True, False, False, False, False]
             ... ], dtype=bool)
-            >>> generate_contour(a)
+            >>> generate_contour_fast(a)
             array([[False, False,  True, False, False, False,  True],
                    [ True, False, False, False,  True, False, False],
                    [ True,  True, False,  True,  True, False,  True],

--- a/nanshe/util/xnumpy.py
+++ b/nanshe/util/xnumpy.py
@@ -4330,7 +4330,7 @@ def generate_contour_fast(a_image):
 
     a_mask = (a_image != 0)
     a_mask ^= mahotas.erode(
-            a_image, structure
+            a_mask, structure
     )
 
     a_image_contours = a_image * a_mask


### PR DESCRIPTION
The function, `generate_contour_fast`, had doctests that did not exercise the function itself. This was clearly some linger copypasta. By fixing this we improve our testing and documentation.

Also turns out there was a type mismatch in the function that was overlooked. This has been fixed now.