### PR TITLE
Drop `functools32` build requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,9 +71,6 @@ elif sys.argv[1] == "bdist_conda":
     ]
 
     if sys.version_info < (3, 2):
-        build_requires += [
-            "functools32"
-        ]
         install_requires += [
             "functools32"
         ]


### PR DESCRIPTION
Drop `functools32` from the build requirements in `setup.py`.