### PR TITLE
Unpinning `conda-build`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ install:
    - echo "python ${PYTHON_VERSION}.*" >> $HOME/miniconda/conda-meta/pinned
    - conda install python=$PYTHON_VERSION
    # Install basic conda dependencies.
-   - echo "conda-build 1.*" >> $HOME/miniconda/conda-meta/pinned
    - conda install conda-build
    # Build the conda package for nanshe.
    - cd $TRAVIS_REPO_SLUG

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
    # Setup environment for nanshe and install it with all dependencies.
    - conda create --use-local -n testenv python=$PYTHON_VERSION nanshe==$VERSION
    - conda update --use-local -n testenv --all
-   - conda install --use-local -n testenv nanshe==$(python setup.py --version)
+   - conda install --use-local -n testenv nanshe==$VERSION
    - source activate testenv
    # Optionally install GPL dependencies.
    - if [[ $USE_GPL == true ]]; then conda install --use-local -n testenv pyfftw; fi


### PR DESCRIPTION
This tries to install `conda-build` 2 and use it to build `nanshe` to see if it works. Given that it works, the pinning will be released in the base image instead of using this hack.