### PR TITLE
Support Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ env:
    - PYTHON_VERSION="2.7" USE_GPL=true
    - PYTHON_VERSION="3.5" USE_GPL=false
    - PYTHON_VERSION="3.5" USE_GPL=true
+   - PYTHON_VERSION="3.6" USE_GPL=false
+   - PYTHON_VERSION="3.6" USE_GPL=true
 before_install:
    # If `$DEPLOY_DOCS` is unset, make it `false` by default.
    - if [ -z $DEPLOY_DOCS ]; then DEPLOY_DOCS=false; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,9 +77,12 @@ script:
    - (hash docstring-coverage && docstring-coverage nanshe | tee .docstring-coverage) || true
 after_success:
    # Install packages for submitting coverage results when they are needed.
-   - conda install python-coveralls
+   - conda create -n covenv python=2.7 coverage=3 python-coveralls
+   - source activate covenv
    # Submit results to coveralls.io.
    - coveralls
+   # Back to the test env.
+   - source activate testenv
    # Check to see if this is the right branch to build documentation from.
    - if [ $TRAVIS_PULL_REQUEST != "false" ] || [ $TRAVIS_REPO_SLUG != "nanshe-org/nanshe" ] || [ $TRAVIS_BRANCH != "master" ]; then exit 0 ; fi
    # Save documentation and documentation coverage statistics.

--- a/nanshe/util/xnumpy.py
+++ b/nanshe/util/xnumpy.py
@@ -757,9 +757,9 @@ def unsquish(new_array, shape, axis=None):
         current_axis_order_iter = iters.irange(len(shape))
 
         # Find how the old order relates to the new one
-        axis_order_map = dict(
-            iters.izip(old_axis_order_iter, current_axis_order_iter)
-        )
+        axis_order_map = collections.OrderedDict(sorted(iters.izip(
+            old_axis_order_iter, current_axis_order_iter
+        )))
 
         # Export how the new order will be changed
         # (as the old axis order will be how to transform the axes).


### PR DESCRIPTION
Start supporting Python 3.6.

* Add Python 3.6 to Travis CI's test matrix.
* Generate a Python 3.6 package for `nose-timer`. ( https://github.com/conda-forge/nose-timer-feedstock/pull/4 )
* Fixed issues with `unsquish` due to changes to the [implementation]( https://mail.python.org/pipermail/python-dev/2016-September/146327.html ) of `dict` in Python 3.6.
* Add a workaround for `coverage`/`coveralls` issues on Python 3.6.