### PR TITLE
Include license file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -153,6 +153,7 @@ setup(
     install_requires=install_requires,
     tests_require=tests_require,
     test_suite="nose.collector",
+    data_files=[('', ['LICENSE.txt'])],
     zip_safe=True,
     conda_import_tests=False,
     conda_command_tests=False


### PR DESCRIPTION
Includes the license file by treating it as a data file. This seems to work with `bdist_conda` based on local testing. So it should allow us to ship the license file with the package.