### PR TITLE
Wrap large and negative shifts

### DIFF
--- a/nanshe/imp/registration.py
+++ b/nanshe/imp/registration.py
@@ -272,6 +272,10 @@ def register_mean_offsets(frames2reg,
                 frames2reg_fft[range_ij], template_fft
             )
 
+        # Translate shifts to fit within one frame.
+        for range_ij in iters.subrange(0, len(frames2reg), block_frame_length):
+            this_space_shift[range_ij] %= numpy.array(frames2reg_fft.shape[1:])
+
         # Remove global shifts.
         this_space_shift_mean[...] = 0
         for range_ij in iters.subrange(0, len(frames2reg), block_frame_length):


### PR DESCRIPTION
If a shift is larger than the frame size, convert to one that is within the frame size. Also if a shift is negative, convert it to one that is positive. This works as we have periodic boundary conditions as a consequence of working in Fourier space. Thus each frame effectively has another frame just like it on all of its boundaries and so on for each of those frames. As a result, a shift equal to frame size in any dimension is just a no-op for that dimension's shift. This allows us to chose the smallest shifts possible.