### PR TITLE
Require tifffile

### DIFF
--- a/nanshe/io/xtiff.py
+++ b/nanshe/io/xtiff.py
@@ -37,12 +37,7 @@ import vigra.impex
 from nanshe.util import iters, xglob, prof, xnumpy
 from nanshe.io import hdf5
 
-try:
-    import tifffile
-except ImportError:
-    # scikit-image is bundled with tifffile so use it.
-    from skimage.external import tifffile
-
+import tifffile
 
 from past.builtins import unicode
 

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ elif sys.argv[1] == "bdist_conda":
         "xnumpy",
         "scikit-image",
         "scikit-learn",
+        "tifffile",
         "yail",
         "mahotas",
         "vigra",


### PR DESCRIPTION
No matter what we need a copy of `tifffile` to process and convert TIFF data. We optionally used the vendored copy of `tifffile` from `scikit-image` previously as this might be an easier way for end users to meet this requirement as it was more generally available. As `tifffile` is available from `conda-forge` and we use that channel for basically all of our dependencies, it doesn't make sense to not use `tifffile` from there as well. This way we have a better chance of having the newest version of `tifffile` available. As `tifffile` is under the BSD 3-clause license, there are no additional constraints from what we already have with `scikit-image` and they are all quite reasonable.