### PR TITLE
Tweak to license inclusion

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -154,7 +154,7 @@ setup(
     install_requires=install_requires,
     tests_require=tests_require,
     test_suite="nose.collector",
-    data_files=[('', ['LICENSE.txt'])],
+    data_files=[("", ["LICENSE.txt"])],
     zip_safe=True,
     conda_import_tests=False,
     conda_command_tests=False


### PR DESCRIPTION
Follow-up to PR ( https://github.com/nanshe-org/nanshe/pull/443 ).

Switches from single quotes to double quotes.