### PR TITLE
Run CI with SPAMS 2.6 on Python 2/3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,8 +47,7 @@ install:
    - conda install --use-local -n testenv nanshe==$VERSION
    - source activate testenv
    # Optionally install GPL dependencies.
-   - if [[ $USE_GPL == true ]]; then conda install --use-local -n testenv pyfftw; fi
-   - if [[ $PYTHON_VERSION == "2.7" ]] && [[ $USE_GPL == true ]]; then conda install --use-local -n testenv python-spams; fi
+   - if [[ $USE_GPL == true ]]; then conda install --use-local -n testenv pyfftw python-spams; fi
    # Install DRMAA with Python support.
    - .travis_scripts/install_sge.sh
    - export SGE_ROOT=/var/lib/gridengine


### PR DESCRIPTION
As SPAMS 2.6 supports Python 3, add it into the matrix for Python 3 as well. This should also touch some code paths that aren't really tested on Python 3 currently. So should improve code quality as well.