### PR TITLE
Update files for coverage to ignore

### DIFF
--- a/setup.all.cfg
+++ b/setup.all.cfg
@@ -3,7 +3,7 @@ verbosity=3
 with-doctest=1
 doctest-tests=1
 with-coverage=1
-ignore-files=setup.py
+ignore-files=(?:^\.|^_,|^setup\.py|_version\.py$)
 [build_sphinx]
 builder=html
 [versioneer]


### PR DESCRIPTION
The `ignore-files` section in `setup.all.cfg` was stale and did not include the latest pattern from `setup.cfg`. So this copies `ignore-files` from `setup.cfg` to `setup.all.cfg`.