### PR TITLE
Drop HDF5 pin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,6 @@ elif sys.argv[1] == "bdist_conda":
         "psutil",
         "numpy",
         "scipy",
-        "hdf5>=1.8.17,<1.8.18",
         "h5py",
         "bottleneck",
         "matplotlib",


### PR DESCRIPTION
This was more important before channel priority was a thing in `conda` to make sure that we didn't get a copy of HDF5 that was ABI compatibility with our other libraries. Now that channel priority works and basically everything we use is in conda-forge using even newer versions of HDF5, we should drop this pinning. After all this is a pure Python library that only interfaces with HDF5 through other Python libraries (e.g. h5py), so pinning doesn't make much sense for any other reason here.

Note: This pinning seems to blocking us from updating to NumPy 1.13 as well.

xref: https://github.com/nanshe-org/nanshe/pull/384
xref: https://github.com/nanshe-org/nanshe/pull/385