### PR TITLE
Drop docstring-coverage from Wercker

### DIFF
--- a/.wercker.yml
+++ b/.wercker.yml
@@ -43,7 +43,6 @@ build:
             code: |-
                 conda install -y nose-timer
                 conda install -y coverage
-                conda install -y docstring-coverage
                 conda install -y python-coveralls
                 conda clean -tipsy
 
@@ -56,7 +55,6 @@ build:
             name: Test documentation.
             code: |-
                 python setup.py build_sphinx
-                docstring-coverage nanshe | tee .docstring-coverage
 
     after-steps:
         - email-notify:

--- a/.wercker.yml
+++ b/.wercker.yml
@@ -55,11 +55,3 @@ build:
             name: Test documentation.
             code: |-
                 python setup.py build_sphinx
-
-    after-steps:
-        - email-notify:
-            from: alerts@wercker.com
-            to: $TO_EMAIL
-            username: $FROM_EMAIL
-            password: $PASS
-            host: smtp.gmail.com:587


### PR DESCRIPTION
As we now use Python 3.6 by default in the `jakirkham/centos_drmaa_conda` image, we should not make use of `docstring-coverage` on Wercker. Hence we stop installing and using it.