### PR TITLE
Require Travis CI's Ubuntu Precise image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: generic
+
+os: linux
+dist: precise
+
 addons:
    hosts:
        - travis


### PR DESCRIPTION
Everything in this configuration file was designed around using Travis CI's Ubuntu Precise image. However it is now being run on their Ubuntu Trusty image where it doesn't appear to work. Force use of the Ubuntu Precise image on Travis CI to return to an image that has been known to work.