### PR TITLE
Close other temp file in HDF5 tests

### DIFF
--- a/tests/test_nanshe/test_io/test_hdf5/test_serializers.py
+++ b/tests/test_nanshe/test_io/test_hdf5/test_serializers.py
@@ -218,6 +218,8 @@ class TestSerializers(object):
         assert (data1[2:8, 2:8].shape == data6.shape)
         assert (data1[2:8, 2:8] == data6).all()
 
+        self.temp_hdf5_file2.close()
+
 
     def test_read_numpy_structured_array_from_HDF5_2(self):
         data1 = numpy.zeros((10, 10), dtype=[("a", float, 2), ("b", int, 3)])


### PR DESCRIPTION
Fixes https://github.com/nanshe-org/nanshe/issues/460
Fixes https://github.com/nanshe-org/nanshe/issues/389 (hopefully)
Closes https://github.com/nanshe-org/nanshe/pull/461

Appears that `test_read_numpy_structured_array_from_HDF5_1` creates another HDF5 file, which it leaves open as the test ends. Hence this blocks the cleanup step at the end of the test. We fix this by closing the second temporary file at the end of this test.