### PR TITLE
WIP: Workaround change in tifffile's memmap feature

### DIFF
--- a/nanshe/io/xtiff.py
+++ b/nanshe/io/xtiff.py
@@ -280,12 +280,12 @@ def get_standard_tiff_data(new_tiff_filename,
 
         for i in iters.irange(
                 0,
-                len(new_tiff_file),
+                len(new_tiff_file.pages),
                 pages_to_channel
         ):
             new_tiff_description.append([])
             for j in iters.irange(pages_to_channel):
-                each_page = new_tiff_file[i + j]
+                each_page = new_tiff_file.pages[i + j]
                 each_metadata = each_page.tags
                 each_desc = u""
 

--- a/nanshe/io/xtiff.py
+++ b/nanshe/io/xtiff.py
@@ -180,7 +180,15 @@ def get_standard_tiff_array(new_tiff_filename,
     assert (pages_to_channel > 0)
 
     with tifffile.TiffFile(new_tiff_filename) as new_tiff_file:
-        new_tiff_array = new_tiff_file.asarray(memmap=memmap)
+        if memmap:
+            try:
+                # tifffile >= 0.13.0
+                new_tiff_array = new_tiff_file.asarray(out="memmap")
+            except TypeError:
+                # tifffile < 0.13.0
+                new_tiff_array = new_tiff_file.asarray(memmap=True)
+        else:
+            new_tiff_array = new_tiff_file.asarray()
 
     # Add a singleton channel if none is present.
     if new_tiff_array.ndim == 3:
@@ -260,7 +268,15 @@ def get_standard_tiff_data(new_tiff_filename,
 
     new_tiff_description = []
     with tifffile.TiffFile(new_tiff_filename) as new_tiff_file:
-        new_tiff_array = new_tiff_file.asarray(memmap=memmap)
+        if memmap:
+            try:
+                # tifffile >= 0.13.0
+                new_tiff_array = new_tiff_file.asarray(out="memmap")
+            except TypeError:
+                # tifffile < 0.13.0
+                new_tiff_array = new_tiff_file.asarray(memmap=True)
+        else:
+            new_tiff_array = new_tiff_file.asarray()
 
         for i in iters.irange(
                 0,


### PR DESCRIPTION
In `tifffile` version `0.13.0`+, it appears that the `memmap` keyword to `asarray` has been dropped. Instead one must use `out` and set it to `"memmap"`. To handle this change while remaining compatible with the old versions of `tifffile`, we try the new syntax and fallback to old syntax if a `TypeError` is raised (happens when the keyword doesn't exist).