### PR TITLE
Pin breaking dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,7 @@ install:
    - python setup.py bdist_conda
    # Setup environment for nanshe and install it with all dependencies.
    - conda create --use-local -n testenv python=$PYTHON_VERSION nanshe==$VERSION
+   - touch $HOME/miniconda/envs/testenv/conda-meta/pinned
    - conda update --use-local -n testenv --all
    - conda install --use-local -n testenv nanshe==$VERSION
    - source activate testenv
@@ -59,6 +60,7 @@ install:
    - export DRMAA_LIBRARY_PATH=/usr/lib/libdrmaa.so.1.0
    - conda install drmaa
    # Install sphinx and friends to build documentation.
+   - echo "sphinx 1.6.*" >> $HOME/miniconda/envs/testenv/conda-meta/pinned
    - conda install sphinx
    - conda install cloud_sptheme
    # Install coverage and coveralls to generate and submit test coverage results for coveralls.io.

--- a/.wercker.yml
+++ b/.wercker.yml
@@ -24,6 +24,7 @@ build:
                 conda create -y --use-local -n testenv nanshe==$(python setup.py --version)
                 source activate testenv
                 conda clean -tipsy
+                touch /opt/conda/envs/testenv/conda-meta/pinned
 
         - script:
             name: Install dependencies for cluster support.
@@ -34,6 +35,7 @@ build:
         - script:
             name: Install dependencies for building docs.
             code: |-
+                echo "sphinx 1.6.*" >> /opt/conda/envs/testenv/conda-meta/pinned
                 conda install -y sphinx
                 conda install -y cloud_sptheme
                 conda clean -tipsy

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ elif sys.argv[1] == "bdist_conda":
         "xnumpy",
         "scikit-image",
         "scikit-learn",
-        "tifffile",
+        "tifffile>=0.12.0,<0.13.0",
         "yail",
         "mahotas",
         "vigra",


### PR DESCRIPTION
Some of `nanshe`'s dependencies have made breaking changes, which broke it. To solve this problem for now until we can actually address all of the issues, pin them to working versions. In particular pin `tifffile` to `0.12.*` and pin `sphinx` to `1.6.*`.