### PR TITLE
Fix tifffile 0.13 breakage

### DIFF
--- a/nanshe/io/xtiff.py
+++ b/nanshe/io/xtiff.py
@@ -280,12 +280,12 @@ def get_standard_tiff_data(new_tiff_filename,
 
         for i in iters.irange(
                 0,
-                len(new_tiff_file),
+                len(new_tiff_file.pages),
                 pages_to_channel
         ):
             new_tiff_description.append([])
             for j in iters.irange(pages_to_channel):
-                each_page = new_tiff_file[i + j]
+                each_page = new_tiff_file.pages[i + j]
                 each_metadata = each_page.tags
                 each_desc = u""
 

--- a/nanshe/io/xtiff.py
+++ b/nanshe/io/xtiff.py
@@ -180,7 +180,15 @@ def get_standard_tiff_array(new_tiff_filename,
     assert (pages_to_channel > 0)
 
     with tifffile.TiffFile(new_tiff_filename) as new_tiff_file:
-        new_tiff_array = new_tiff_file.asarray(memmap=memmap)
+        if memmap:
+            try:
+                # tifffile >= 0.13.0
+                new_tiff_array = new_tiff_file.asarray(out="memmap")
+            except TypeError:
+                # tifffile < 0.13.0
+                new_tiff_array = new_tiff_file.asarray(memmap=True)
+        else:
+            new_tiff_array = new_tiff_file.asarray()
 
     # Add a singleton channel if none is present.
     if new_tiff_array.ndim == 3:
@@ -260,7 +268,15 @@ def get_standard_tiff_data(new_tiff_filename,
 
     new_tiff_description = []
     with tifffile.TiffFile(new_tiff_filename) as new_tiff_file:
-        new_tiff_array = new_tiff_file.asarray(memmap=memmap)
+        if memmap:
+            try:
+                # tifffile >= 0.13.0
+                new_tiff_array = new_tiff_file.asarray(out="memmap")
+            except TypeError:
+                # tifffile < 0.13.0
+                new_tiff_array = new_tiff_file.asarray(memmap=True)
+        else:
+            new_tiff_array = new_tiff_file.asarray()
 
         for i in iters.irange(
                 0,

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ elif sys.argv[1] == "bdist_conda":
         "xnumpy",
         "scikit-image",
         "scikit-learn",
-        "tifffile>=0.12.0,<0.13.0",
+        "tifffile",
         "yail",
         "mahotas",
         "vigra",


### PR DESCRIPTION
Makes some changes to handle breaking changes in `tifffile` 0.13+. Does this in such a way so as to keep compatibility with older versions of `tifffile` as well.