### PR TITLE
Switch from `memory_info_ex` to `memory_info`

### DIFF
--- a/nanshe/util/prof.py
+++ b/nanshe/util/prof.py
@@ -341,6 +341,6 @@ def memory_profiler(logger, interval=1, level=logging.INFO):
 
     while memory_profiler.to_run:
         logger.log(
-            level, "Memory info = " + repr(current_process.memory_info_ex())
+            level, "Memory info = " + repr(current_process.memory_info())
         )
         time.sleep(interval)


### PR DESCRIPTION
As `memory_info_ex` is (and has been for some time) deprecated, switch to using `memory_info`, which behaves identically and is not deprecated.

xref: https://github.com/giampaolo/psutil/pull/757