### PR TITLE
Use Miniconda 4.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
    - pwd
 install:
    # Download and configure conda.
-   - wget http://repo.continuum.io/miniconda/Miniconda`echo ${PYTHON_VERSION:0:1}`-latest-Linux-x86_64.sh -O miniconda.sh
+   - wget http://repo.continuum.io/miniconda/Miniconda`echo ${PYTHON_VERSION:0:1}`-4.3.31-Linux-x86_64.sh -O miniconda.sh
    - bash miniconda.sh -b -p $HOME/miniconda
    - export PATH="$HOME/miniconda/bin:$PATH"
    - conda config --set always_yes yes


### PR DESCRIPTION
As downgrading to conda 4.3 from conda 4.4 somehow breaks conda, start with Miniconda based off of conda 4.3 to start with. This is needed as conda 4.3 is the latest version of conda in conda-forge. So the downgrade will happen regardless due to channel priority.