### PR TITLE
Drop Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ addons:
 env:
    - PYTHON_VERSION="2.7" USE_GPL=false DEPLOY_DOCS=true
    - PYTHON_VERSION="2.7" USE_GPL=true
-   - PYTHON_VERSION="3.5" USE_GPL=false
-   - PYTHON_VERSION="3.5" USE_GPL=true
    - PYTHON_VERSION="3.6" USE_GPL=false
    - PYTHON_VERSION="3.6" USE_GPL=true
    - PYTHON_VERSION="3.7" USE_GPL=false


### PR DESCRIPTION
We are now using Python 3.6 and 3.7 is being added. There appear to be some issues testing Python 3.5 due to some dependency changes under the hood. Given these, go ahead and drop Python 3.5.