### PR TITLE
Drop python-coveralls on Wercker

### DIFF
--- a/.wercker.yml
+++ b/.wercker.yml
@@ -44,7 +44,6 @@ build:
             code: |-
                 conda install -y nose-timer
                 conda install -y coverage
-                conda install -y python-coveralls
                 conda clean -tipsy
 
         - script:


### PR DESCRIPTION
We don't actually submit test coverage from Wercker currently as it has been somewhat difficult to do historically and Travis CI already submits coverage information. As such we don't need python-coveralls installed on Wercker as we are not using it there. Plus we seem to have some issues installing it due to its rather older pin on Coverage 4.0.3. So go ahead and drop python-coveralls from the Wercker build in hopes of getting things working there again.