### PR TITLE
Drop `matplotlib` requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,6 @@ elif sys.argv[1] == "bdist_conda":
         "scipy",
         "h5py",
         "bottleneck",
-        "matplotlib",
         "imgroi",
         "kenjutsu",
         "metawrap",


### PR DESCRIPTION
We are not making direct usage of `matplotlib` internally. Instead we require `mplview` to provide a GUI for looking at data, which in turn requires `matplotlib`. So there is really no need to make it a requirement any more. Given this, go ahead and drop the `matplotlib` requirement from `setup.py`.