### PR TITLE
Drop `setuptools` install requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ elif sys.argv[1] == "bdist_conda":
     install_requires = [
         "blas==1.1",
         "openblas",
-        "setuptools",
         "future",
         "psutil",
         "numpy",


### PR DESCRIPTION
We only use `setuptools` for the build. It is not used at install time. So go ahead and drop it from the install requirements.