### PR TITLE
Only install docstring-coverage on doc deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ install:
    # Also, install docstring-coverage to get information about documentation coverage.
    - conda install nose-timer
    - conda install coverage
-   - conda install docstring-coverage || true
+   - if [[ $DEPLOY_DOCS == true ]]; then conda install docstring-coverage; fi
    # Clean up downloads as there are quite a few and they waste space/memory.
    - sudo apt-get clean
    - conda clean -tipsy


### PR DESCRIPTION
As it appears to be expensive to install `docstring-coverage` particularly when it cannot be installed, only install `docstring-coverage` when the docs are to be deployed. This should cutdown on CI time significantly (particularly on Python 3 where `docstring-coverage` cannot be installed).