### PR TITLE
Require NumPy 1.11+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ elif sys.argv[1] == "bdist_conda":
         "openblas",
         "future",
         "psutil",
-        "numpy",
+        "numpy >=1.11",
         "scipy",
         "h5py",
         "bottleneck",


### PR DESCRIPTION
This is a workaround for a conda-build bug in `bdist_conda`. ( https://github.com/conda/conda-build/issues/3333 ) However having a constraint for NumPy here is reasonable. Though the code was designed for such an old version of NumPy that most versions likely work without issues. For now we make the requirement 1.11 as we are unlikely to go further back than that.